### PR TITLE
Add UCAS link builder to search api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj
 node_modules
 *.tmp
 src/domain/publish/*
+.vs

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,7 +30,8 @@
                 }
             },
             "env": {
-                "ASPNETCORE_ENVIRONMENT": "Development"
+                "ASPNETCORE_ENVIRONMENT": "Development",
+                "ASPNETCORE_URLS": "http://*:5001"
             },
             "sourceFileMap": {
                 "/Views": "${workspaceFolder}/Views"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,6 +10,16 @@
                 "${workspaceFolder}/src/api/SearchAndCompareApi.csproj"
             ],
             "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "build-tests",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/tests/SearchAndCompareApi.Tests.csproj"
+            ],
+            "problemMatcher": "$msCompile"
         }
     ]
 }

--- a/SearchAndCompareApi.sln
+++ b/SearchAndCompareApi.sln
@@ -1,15 +1,14 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{8AADBC4E-F2FA-4FAF-B5C4-85814F9AE50B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SearchAndCompareApi", "src\api\SearchAndCompareApi.csproj", "{77395BF7-765E-466A-A5EE-CD33F808D51A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SearchAndCompareApi", "src\api\SearchAndCompareApi.csproj", "{77395BF7-765E-466A-A5EE-CD33F808D51A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SearchAndCompareDomain", "src\domain\SearchAndCompareDomain.csproj", "{B8FAC89F-C87D-4664-8757-803B6907240E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SearchAndCompareDomain", "src\domain\SearchAndCompareDomain.csproj", "{B8FAC89F-C87D-4664-8757-803B6907240E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SearchAndCompareApi.Tests", "tests\SearchAndCompareApi.Tests.csproj", "{A1371B3C-E6A9-4179-81D7-A895A6648CC7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SearchAndCompareApi.Tests", "tests\SearchAndCompareApi.Tests.csproj", "{A1371B3C-E6A9-4179-81D7-A895A6648CC7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -20,49 +19,52 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{77395BF7-765E-466A-A5EE-CD33F808D51A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{77395BF7-765E-466A-A5EE-CD33F808D51A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{77395BF7-765E-466A-A5EE-CD33F808D51A}.Debug|x64.ActiveCfg = Debug|x64
-		{77395BF7-765E-466A-A5EE-CD33F808D51A}.Debug|x64.Build.0 = Debug|x64
-		{77395BF7-765E-466A-A5EE-CD33F808D51A}.Debug|x86.ActiveCfg = Debug|x86
-		{77395BF7-765E-466A-A5EE-CD33F808D51A}.Debug|x86.Build.0 = Debug|x86
+		{77395BF7-765E-466A-A5EE-CD33F808D51A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{77395BF7-765E-466A-A5EE-CD33F808D51A}.Debug|x64.Build.0 = Debug|Any CPU
+		{77395BF7-765E-466A-A5EE-CD33F808D51A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{77395BF7-765E-466A-A5EE-CD33F808D51A}.Debug|x86.Build.0 = Debug|Any CPU
 		{77395BF7-765E-466A-A5EE-CD33F808D51A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{77395BF7-765E-466A-A5EE-CD33F808D51A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{77395BF7-765E-466A-A5EE-CD33F808D51A}.Release|x64.ActiveCfg = Release|x64
-		{77395BF7-765E-466A-A5EE-CD33F808D51A}.Release|x64.Build.0 = Release|x64
-		{77395BF7-765E-466A-A5EE-CD33F808D51A}.Release|x86.ActiveCfg = Release|x86
-		{77395BF7-765E-466A-A5EE-CD33F808D51A}.Release|x86.Build.0 = Release|x86
+		{77395BF7-765E-466A-A5EE-CD33F808D51A}.Release|x64.ActiveCfg = Release|Any CPU
+		{77395BF7-765E-466A-A5EE-CD33F808D51A}.Release|x64.Build.0 = Release|Any CPU
+		{77395BF7-765E-466A-A5EE-CD33F808D51A}.Release|x86.ActiveCfg = Release|Any CPU
+		{77395BF7-765E-466A-A5EE-CD33F808D51A}.Release|x86.Build.0 = Release|Any CPU
 		{B8FAC89F-C87D-4664-8757-803B6907240E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B8FAC89F-C87D-4664-8757-803B6907240E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B8FAC89F-C87D-4664-8757-803B6907240E}.Debug|x64.ActiveCfg = Debug|x64
-		{B8FAC89F-C87D-4664-8757-803B6907240E}.Debug|x64.Build.0 = Debug|x64
-		{B8FAC89F-C87D-4664-8757-803B6907240E}.Debug|x86.ActiveCfg = Debug|x86
-		{B8FAC89F-C87D-4664-8757-803B6907240E}.Debug|x86.Build.0 = Debug|x86
+		{B8FAC89F-C87D-4664-8757-803B6907240E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B8FAC89F-C87D-4664-8757-803B6907240E}.Debug|x64.Build.0 = Debug|Any CPU
+		{B8FAC89F-C87D-4664-8757-803B6907240E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B8FAC89F-C87D-4664-8757-803B6907240E}.Debug|x86.Build.0 = Debug|Any CPU
 		{B8FAC89F-C87D-4664-8757-803B6907240E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B8FAC89F-C87D-4664-8757-803B6907240E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B8FAC89F-C87D-4664-8757-803B6907240E}.Release|x64.ActiveCfg = Release|x64
-		{B8FAC89F-C87D-4664-8757-803B6907240E}.Release|x64.Build.0 = Release|x64
-		{B8FAC89F-C87D-4664-8757-803B6907240E}.Release|x86.ActiveCfg = Release|x86
-		{B8FAC89F-C87D-4664-8757-803B6907240E}.Release|x86.Build.0 = Release|x86
+		{B8FAC89F-C87D-4664-8757-803B6907240E}.Release|x64.ActiveCfg = Release|Any CPU
+		{B8FAC89F-C87D-4664-8757-803B6907240E}.Release|x64.Build.0 = Release|Any CPU
+		{B8FAC89F-C87D-4664-8757-803B6907240E}.Release|x86.ActiveCfg = Release|Any CPU
+		{B8FAC89F-C87D-4664-8757-803B6907240E}.Release|x86.Build.0 = Release|Any CPU
 		{A1371B3C-E6A9-4179-81D7-A895A6648CC7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A1371B3C-E6A9-4179-81D7-A895A6648CC7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A1371B3C-E6A9-4179-81D7-A895A6648CC7}.Debug|x64.ActiveCfg = Debug|x64
-		{A1371B3C-E6A9-4179-81D7-A895A6648CC7}.Debug|x64.Build.0 = Debug|x64
-		{A1371B3C-E6A9-4179-81D7-A895A6648CC7}.Debug|x86.ActiveCfg = Debug|x86
-		{A1371B3C-E6A9-4179-81D7-A895A6648CC7}.Debug|x86.Build.0 = Debug|x86
+		{A1371B3C-E6A9-4179-81D7-A895A6648CC7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A1371B3C-E6A9-4179-81D7-A895A6648CC7}.Debug|x64.Build.0 = Debug|Any CPU
+		{A1371B3C-E6A9-4179-81D7-A895A6648CC7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A1371B3C-E6A9-4179-81D7-A895A6648CC7}.Debug|x86.Build.0 = Debug|Any CPU
 		{A1371B3C-E6A9-4179-81D7-A895A6648CC7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1371B3C-E6A9-4179-81D7-A895A6648CC7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A1371B3C-E6A9-4179-81D7-A895A6648CC7}.Release|x64.ActiveCfg = Release|x64
-		{A1371B3C-E6A9-4179-81D7-A895A6648CC7}.Release|x64.Build.0 = Release|x64
-		{A1371B3C-E6A9-4179-81D7-A895A6648CC7}.Release|x86.ActiveCfg = Release|x86
-		{A1371B3C-E6A9-4179-81D7-A895A6648CC7}.Release|x86.Build.0 = Release|x86
+		{A1371B3C-E6A9-4179-81D7-A895A6648CC7}.Release|x64.ActiveCfg = Release|Any CPU
+		{A1371B3C-E6A9-4179-81D7-A895A6648CC7}.Release|x64.Build.0 = Release|Any CPU
+		{A1371B3C-E6A9-4179-81D7-A895A6648CC7}.Release|x86.ActiveCfg = Release|Any CPU
+		{A1371B3C-E6A9-4179-81D7-A895A6648CC7}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{77395BF7-765E-466A-A5EE-CD33F808D51A} = {8AADBC4E-F2FA-4FAF-B5C4-85814F9AE50B}
 		{B8FAC89F-C87D-4664-8757-803B6907240E} = {8AADBC4E-F2FA-4FAF-B5C4-85814F9AE50B}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7FDDA4EC-0616-4719-9FC2-3E2BA3D44364}
 	EndGlobalSection
 EndGlobal

--- a/src/api/Controllers/UcasController.cs
+++ b/src/api/Controllers/UcasController.cs
@@ -32,14 +32,17 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
         [HttpGet("course-url")]
         public async Task<IActionResult> GetUcasCourseUrl(int courseId)
         {
-            var sessionId = GetSessionId();
+            var sessionId = await GetSessionId();
+
             // todo: include provider
-            var course = _context.Courses.FindAsync(courseId).Result;
+            var course = await _context.Courses.FindAsync(courseId);
+
             if (course == null){
                 return NotFound();
             }
 
             var courseUrl = GenerateCourseUrl(course, sessionId);
+
             return Ok(courseUrl);
         }
 
@@ -53,10 +56,10 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
             return Ok(url);
         }
 
-        private string GetSessionId()
+        private async Task<string> GetSessionId()
         {
             const string searchStartUrl = "http://search.gttr.ac.uk/cgi-bin/hsrun.hse/General/2018_gttr_search/gttr_search.hjx;start=gttr_search.HsForm.run";
-            var response = _httpClient.GetAsync(searchStartUrl).Result;
+            var response = await _httpClient.GetAsync(searchStartUrl);
             if (!response.IsSuccessStatusCode)
             {
                 // todo: improve handling
@@ -70,7 +73,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
                 throw new Exception("content type header missing in ucas site response");
             }
             var contentType = response.Content.Headers.FirstOrDefault(header => header.Key == contentTypeHeader).Value.FirstOrDefault();
-            var ucasBytes = response.Content.ReadAsByteArrayAsync().Result;
+            var ucasBytes = await response.Content.ReadAsByteArrayAsync();
             var ucasHtml = Encoding.GetEncoding(1252).GetString(ucasBytes);
             var matchCollection = Regex.Matches(ucasHtml, @"StateId\/([^\/]*)\/");
             var stateId = matchCollection.First().Groups.Skip(1).First().Captures.First().Value;

--- a/src/api/Controllers/UcasController.cs
+++ b/src/api/Controllers/UcasController.cs
@@ -86,6 +86,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
         public string ExtractStateId(string ucasHtml)
         {
             var matchCollection = Regex.Matches(ucasHtml, @"StateId\/([^\/]*)\/");
+
             var stateId = matchCollection.First().Groups.Skip(1).First().Captures.First().Value;
 
             return stateId;

--- a/src/api/Controllers/UcasController.cs
+++ b/src/api/Controllers/UcasController.cs
@@ -17,7 +17,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
         public async Task<IActionResult> GetUcasCourseUrl(string programmeCode, string providerCode)
         {
             // todo: grab sessionId, build actual url for course
-            return Ok("http://search.gttr.ac.uk/cgi-bin/hsrun.hse/General/2018_gttr_search/gttr_search.hjx;start=gttr_search.HsForm.run");
+            return Ok("http://search.gttr.ac.uk/cgi-bin/hsrun.hse/General/2018_gttr_search/StateId/FtZTMVzsnznHD12F9RlkEsGMDpCWs-VuyG/HAHTpage/gttr_search.HsProfile.run?inst=295&course=37T6&mod=");
         }
     }
 }

--- a/src/api/Controllers/UcasController.cs
+++ b/src/api/Controllers/UcasController.cs
@@ -1,4 +1,11 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using GovUk.Education.SearchAndCompare.Api.DatabaseAccess;
+using GovUk.Education.SearchAndCompare.Domain.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.SearchAndCompare.Api.Controllers
@@ -9,6 +16,15 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
     [Route("api/[controller]")]
     public class UcasController : Controller
     {
+        private readonly ICourseDbContext _context;
+        private readonly HttpClient _httpClient;
+
+        public UcasController(ICourseDbContext courseDbContext, HttpClient httpClient)
+        {
+            _context = courseDbContext;
+            _httpClient = httpClient;
+        }
+
         /// <summary>
         /// Get a valid sessionId from the ucas site and then return a url for the course.
         /// The url will only be valid while the session is valid! (5 mins at last test)
@@ -16,8 +32,49 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
         [HttpGet("course-url")]
         public async Task<IActionResult> GetUcasCourseUrl(int courseId)
         {
-            // todo: grab sessionId, build actual url for course
-            return Ok("http://search.gttr.ac.uk/cgi-bin/hsrun.hse/General/2018_gttr_search/StateId/FtZTMVzsnznHD12F9RlkEsGMDpCWs-VuyG/HAHTpage/gttr_search.HsProfile.run?inst=295&course=37T6&mod=");
+            var sessionId = GetSessionId();
+            // todo: include provider
+            var course = _context.Courses.FindAsync(courseId).Result;
+            if (course == null){
+                return NotFound();
+            }
+
+            var courseUrl = GenerateCourseUrl(course, sessionId);
+            return Ok(courseUrl);
+        }
+
+        private object GenerateCourseUrl(Course course, string sessionId)
+        {
+            var inst = course.Provider.ProviderCode;
+            var courseCode = course.ProgrammeCode;
+            const string modifier = "";
+            // e.g. "http://search.gttr.ac.uk/cgi-bin/hsrun.hse/General/2018_gttr_search/StateId/FtZTMVzsnznHD12F9RlkEsGMDpCWs-VuyG/HAHTpage/gttr_search.HsProfile.run?inst=295&course=37T6&mod="
+            var url = string.Format($"http://search.gttr.ac.uk/cgi-bin/hsrun.hse/General/2018_gttr_search/StateId/{sessionId}/HAHTpage/gttr_search.HsProfile.run?inst={inst}&course={courseCode}&mod={modifier}");
+            return Ok(url);
+        }
+
+        private string GetSessionId()
+        {
+            const string searchStartUrl = "http://search.gttr.ac.uk/cgi-bin/hsrun.hse/General/2018_gttr_search/gttr_search.hjx;start=gttr_search.HsForm.run";
+            var response = _httpClient.GetAsync(searchStartUrl).Result;
+            if (!response.IsSuccessStatusCode)
+            {
+                // todo: improve handling
+                throw new Exception("ucas request failed");
+            }
+
+            const string contentTypeHeader = "Content-Type";
+            if (!response.Content.Headers.Contains(contentTypeHeader))
+            {
+                // todo: be more tolerant
+                throw new Exception("content type header missing in ucas site response");
+            }
+            var contentType = response.Content.Headers.FirstOrDefault(header => header.Key == contentTypeHeader).Value.FirstOrDefault();
+            var ucasBytes = response.Content.ReadAsByteArrayAsync().Result;
+            var ucasHtml = Encoding.GetEncoding(1252).GetString(ucasBytes);
+            var matchCollection = Regex.Matches(ucasHtml, @"StateId\/([^\/]*)\/");
+            var stateId = matchCollection.First().Groups.Skip(1).First().Captures.First().Value;
+            return stateId;
         }
     }
 }

--- a/src/api/Controllers/UcasController.cs
+++ b/src/api/Controllers/UcasController.cs
@@ -14,7 +14,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
         /// The url will only be valid while the session is valid! (5 mins at last test)
         /// </summary>
         [HttpGet("course-url")]
-        public async Task<IActionResult> GetUcasCourseUrl(string programmeCode, string providerCode)
+        public async Task<IActionResult> GetUcasCourseUrl(int courseId)
         {
             // todo: grab sessionId, build actual url for course
             return Ok("http://search.gttr.ac.uk/cgi-bin/hsrun.hse/General/2018_gttr_search/StateId/FtZTMVzsnznHD12F9RlkEsGMDpCWs-VuyG/HAHTpage/gttr_search.HsProfile.run?inst=295&course=37T6&mod=");

--- a/src/api/Controllers/UcasController.cs
+++ b/src/api/Controllers/UcasController.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.SearchAndCompare.Api.Controllers
+{
+    /// <summary>
+    /// All dealings with the ucas website
+    /// </summary>
+    [Route("api/[controller]")]
+    public class UcasController : Controller
+    {
+        /// <summary>
+        /// Get a valid sessionId from the ucas site and then return a url for the course.
+        /// The url will only be valid while the session is valid! (5 mins at last test)
+        /// </summary>
+        [HttpGet("course-url")]
+        public async Task<IActionResult> GetUcasCourseUrl(string programmeCode, string providerCode)
+        {
+            // todo: grab sessionId, build actual url for course
+            return Ok("http://search.gttr.ac.uk/cgi-bin/hsrun.hse/General/2018_gttr_search/gttr_search.hjx;start=gttr_search.HsForm.run");
+        }
+    }
+}

--- a/src/api/Controllers/UcasController.cs
+++ b/src/api/Controllers/UcasController.cs
@@ -75,7 +75,9 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
             }
             var contentType = response.Content.Headers.FirstOrDefault(header => header.Key == contentTypeHeader).Value.FirstOrDefault();
             var ucasBytes = await response.Content.ReadAsByteArrayAsync();
-            var ucasHtml = Encoding.GetEncoding(1252).GetString(ucasBytes);
+
+            var enc1252 = CodePagesEncodingProvider.Instance.GetEncoding(1252);
+            var ucasHtml = enc1252.GetString(ucasBytes);
             var stateId = ExtractStateId(ucasHtml);
             return stateId;
         }

--- a/src/api/Migrations/20180427164638_CourseModColumn.Designer.cs
+++ b/src/api/Migrations/20180427164638_CourseModColumn.Designer.cs
@@ -12,9 +12,10 @@ using System;
 namespace SearchAndCompare.Migrations
 {
     [DbContext(typeof(CourseDbContext))]
-    partial class CourseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20180427164638_CourseModColumn")]
+    partial class CourseModColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/api/Migrations/20180427164638_CourseModColumn.cs
+++ b/src/api/Migrations/20180427164638_CourseModColumn.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+using System.Collections.Generic;
+
+namespace SearchAndCompare.Migrations
+{
+    public partial class CourseModColumn : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Mod",
+                table: "course",
+                type: "text",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Mod",
+                table: "course");
+        }
+    }
+}

--- a/src/api/Properties/launchSettings.json
+++ b/src/api/Properties/launchSettings.json
@@ -1,0 +1,28 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:5001/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "SearchAndCompareApi": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_URLS": "http://*:5001"
+      },
+      "applicationUrl": "http://localhost:5001/"
+    }
+  }
+}

--- a/src/api/Properties/launchSettings.json
+++ b/src/api/Properties/launchSettings.json
@@ -11,6 +11,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
+      "launchUrl": "/api/ucas/course-url?courseId=25",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -19,8 +20,8 @@
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_URLS": "http://*:5001"
+        "ASPNETCORE_URLS": "http://*:5001",
+        "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "applicationUrl": "http://localhost:5001/"
     }

--- a/src/api/SearchAndCompareApi.csproj
+++ b/src/api/SearchAndCompareApi.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.0.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/api/Startup.cs
+++ b/src/api/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using GovUk.Education.SearchAndCompare.Api;
 using GovUk.Education.SearchAndCompare.Api.DatabaseAccess;
@@ -42,6 +43,7 @@ namespace GovUk.Education.SearchAndCompare.Api
             }
             );;
             services.AddScoped<ICourseDbContext>(provider => provider.GetService<CourseDbContext>());
+            services.AddScoped(provider => new HttpClient());
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -67,6 +69,9 @@ namespace GovUk.Education.SearchAndCompare.Api
             }
 
             app.UseMvc(routes => {});
+
+            // for reading ucas site we need 1252 available
+            System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
         }
     }
 }

--- a/src/api/Startup.cs
+++ b/src/api/Startup.cs
@@ -32,18 +32,19 @@ namespace GovUk.Education.SearchAndCompare.Api
         public void ConfigureServices(IServiceCollection services)
         {
             var connectionString = new EnvConfigConnectionStringBuilder().GetConnectionString(Configuration);
-            
+
             services.AddEntityFrameworkNpgsql().AddDbContext<CourseDbContext>(options => options
                 .UseNpgsql(connectionString));
-                
+
             services.AddMvc().AddJsonOptions(
-            options => {
-                options.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
-                options.SerializerSettings.PreserveReferencesHandling = Newtonsoft.Json.PreserveReferencesHandling.Objects;
-            }
-            );;
+                options => {
+                    options.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+                    options.SerializerSettings.PreserveReferencesHandling = Newtonsoft.Json.PreserveReferencesHandling.Objects;
+                }
+            );
             services.AddScoped<ICourseDbContext>(provider => provider.GetService<CourseDbContext>());
             services.AddScoped(provider => new HttpClient());
+            services.Configure<UcasSettings>(Configuration.GetSection("UcasSettings"));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/api/UcasSettings.cs
+++ b/src/api/UcasSettings.cs
@@ -2,7 +2,6 @@ namespace GovUk.Education.SearchAndCompare.Api
 {
     public class UcasSettings
     {
-
         public string GenerateCourseUrlFormat { get; set; }
         public string  SearchStartUrl { get; set; }
         public string ExtractStateIdRegex { get; set; }

--- a/src/api/UcasSettings.cs
+++ b/src/api/UcasSettings.cs
@@ -1,0 +1,10 @@
+namespace GovUk.Education.SearchAndCompare.Api
+{
+    public class UcasSettings
+    {
+
+        public string GenerateCourseUrlFormat { get; set; }
+        public string  SearchStartUrl { get; set; }
+        public string ExtractStateIdRegex { get; set; }
+    }
+}

--- a/src/api/appsettings.json
+++ b/src/api/appsettings.json
@@ -10,11 +10,17 @@
       "Default": "Warning"
     }
   },
-  "DatabaseConnection": { 
+  "DatabaseConnection": {
     "Server": "localhost",
     "Port": "5432",
     "Database": "courses",
     "Username": "postgres",
-    "Password": "postgres" 
+    "Password": "postgres"
+  },
+  "UcasSettings": {
+    "GenerateCourseUrlFormat":"http://search.gttr.ac.uk/cgi-bin/hsrun.hse/General/2018_gttr_search/StateId/{3}/HAHTpage/gttr_search.HsProfile.run?inst={0}&course={1}&mod={2}",
+    "SearchStartUrl": "http://search.gttr.ac.uk/cgi-bin/hsrun.hse/General/2018_gttr_search/gttr_search.hjx;start=gttr_search.HsForm.run",
+    "ExtractStateIdRegex": "StateId\\/([^\\/]*)\\/"
+
   }
 }

--- a/src/domain/Client/ISearchAndCompareApi.cs
+++ b/src/domain/Client/ISearchAndCompareApi.cs
@@ -19,6 +19,6 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
 
         List<Provider> GetProviderSuggestions(string query);
 
-        string GetUcasCourseUrl(string programmeCode, string providerCode);
+        string GetUcasCourseUrl(int courseId);
     }
 }

--- a/src/domain/Client/ISearchAndCompareApi.cs
+++ b/src/domain/Client/ISearchAndCompareApi.cs
@@ -18,5 +18,7 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
         List<FeeCaps> GetFeeCaps();
 
         List<Provider> GetProviderSuggestions(string query);
+
+        string GetUcasCourseUrl(string courseCode, string institutionCode, string modifier);
     }
 }

--- a/src/domain/Client/ISearchAndCompareApi.cs
+++ b/src/domain/Client/ISearchAndCompareApi.cs
@@ -19,6 +19,6 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
 
         List<Provider> GetProviderSuggestions(string query);
 
-        string GetUcasCourseUrl(string courseCode, string institutionCode, string modifier);
+        string GetUcasCourseUrl(string programmeCode, string providerCode);
     }
 }

--- a/src/domain/Client/SearchAndCompareApi.cs
+++ b/src/domain/Client/SearchAndCompareApi.cs
@@ -67,7 +67,7 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
             return GetObjects<List<Provider>>(buider.Uri) ?? new List<Provider>();
         }
 
-        public string GetUcasCourseUrl(string courseCode, string institutionCode, string modifier)
+        public string GetUcasCourseUrl(string programmeCode, string providerCode)
         {
             // todo: get url from api
             return "http://search.gttr.ac.uk/cgi-bin/hsrun.hse/General/2018_gttr_search/gttr_search.hjx;start=gttr_search.HsForm.run";

--- a/src/domain/Client/SearchAndCompareApi.cs
+++ b/src/domain/Client/SearchAndCompareApi.cs
@@ -7,6 +7,7 @@ using GovUk.Education.SearchAndCompare.Domain.Filters;
 using GovUk.Education.SearchAndCompare.Domain.Lists;
 using GovUk.Education.SearchAndCompare.Domain.Models;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace GovUk.Education.SearchAndCompare.Domain.Client
 {
@@ -63,14 +64,17 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
             var buider = new UriBuilder(new Uri(_apiUri));
             buider.Path += "/providers/suggest";
             buider.Query = "query=" + HttpUtility.UrlEncode(query);
-            
+
             return GetObjects<List<Provider>>(buider.Uri) ?? new List<Provider>();
         }
 
         public string GetUcasCourseUrl(int courseId)
         {
-            // todo: get url from api
-            return "http://search.gttr.ac.uk/cgi-bin/hsrun.hse/General/2018_gttr_search/gttr_search.hjx;start=gttr_search.HsForm.run";
+            var queryUri = GetUri(string.Format("/ucas/course-url/{0}", courseId), null);
+
+            dynamic result =  GetObjects<JObject>(queryUri);;
+
+            return result.courseUrl;
         }
 
         private T GetObjects<T>(Uri queryUri)

--- a/src/domain/Client/SearchAndCompareApi.cs
+++ b/src/domain/Client/SearchAndCompareApi.cs
@@ -67,7 +67,7 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
             return GetObjects<List<Provider>>(buider.Uri) ?? new List<Provider>();
         }
 
-        public string GetUcasCourseUrl(string programmeCode, string providerCode)
+        public string GetUcasCourseUrl(int courseId)
         {
             // todo: get url from api
             return "http://search.gttr.ac.uk/cgi-bin/hsrun.hse/General/2018_gttr_search/gttr_search.hjx;start=gttr_search.HsForm.run";

--- a/src/domain/Client/SearchAndCompareApi.cs
+++ b/src/domain/Client/SearchAndCompareApi.cs
@@ -67,6 +67,12 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
             return GetObjects<List<Provider>>(buider.Uri) ?? new List<Provider>();
         }
 
+        public string GetUcasCourseUrl(string courseCode, string institutionCode, string modifier)
+        {
+            // todo: get url from api
+            return "http://search.gttr.ac.uk/cgi-bin/hsrun.hse/General/2018_gttr_search/gttr_search.hjx;start=gttr_search.HsForm.run";
+        }
+
         private T GetObjects<T>(Uri queryUri)
         {
             T objects = default(T);

--- a/src/domain/Models/Course.cs
+++ b/src/domain/Models/Course.cs
@@ -65,5 +65,7 @@ namespace GovUk.Education.SearchAndCompare.Domain.Models
         public DateTime? StartDate { get; set; }
 
         public string Duration { get; set; }
+
+       public string Mod { get; set; }
     }
 }

--- a/src/domain/SearchAndCompareDomain.csproj
+++ b/src/domain/SearchAndCompareDomain.csproj
@@ -6,7 +6,7 @@
     <Authors>DfE Digital</Authors>
     <Title>Domain objects for SearchAndCompare project</Title>
     <Description>Domain objects for SearchAndCompare project</Description>
-    <VersionPrefix>0.2.3</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
   </PropertyGroup>
 

--- a/tests/Integration.Tests/DatabaseAccess/CourseDbContextIntegrationBase.cs
+++ b/tests/Integration.Tests/DatabaseAccess/CourseDbContextIntegrationBase.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GovUk.Education.SearchAndCompare.Api.DatabaseAccess;
+using GovUk.Education.SearchAndCompare.Domain.Models;
+using GovUk.Education.SearchAndCompare.Domain.Models.Joins;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace GovUk.Education.SearchAndCompare.Api.Integration.Tests.DatabaseAccess
+{
+    public class CourseDbContextIntegrationBase
+    {
+        protected CourseDbContext context;
+
+        protected IList<EntityEntry> entitiesToCleanUp = new List<EntityEntry>();
+
+        protected CourseDbContext GetContext()
+        {
+            var config = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("integration-tests.json")
+                .Build();
+
+            var options = new DbContextOptionsBuilder<CourseDbContext>()
+                .UseNpgsql(new EnvConfigConnectionStringBuilder().GetConnectionString(config))
+                .Options;
+
+            return new CourseDbContext(options);
+        }
+
+        [OneTimeSetUp]
+        public void SetUpFixture()
+        {
+            context = GetContext();
+            context.Database.EnsureDeleted();
+            context.Database.Migrate();
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            context = GetContext();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (entitiesToCleanUp.Any())
+            {
+                foreach (var e in entitiesToCleanUp)
+                {
+                    e.State = EntityState.Deleted;
+                }
+                entitiesToCleanUp.Clear();
+                context.SaveChanges();
+            }
+        }
+
+        [OneTimeTearDown]
+        public void TearDownFixture()
+        {
+            context = GetContext();
+            context.Database.EnsureDeleted();
+        }
+
+        [Test]
+        public void EnsureCreated()
+        {
+            Assert.False(context.Database.EnsureCreated());
+        }
+    }
+}

--- a/tests/Integration.Tests/DatabaseAccess/CourseDbContextIntegrationTests.cs
+++ b/tests/Integration.Tests/DatabaseAccess/CourseDbContextIntegrationTests.cs
@@ -10,72 +10,14 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
 
-namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.DatabaseAccess 
+namespace GovUk.Education.SearchAndCompare.Api.Integration.Tests.DatabaseAccess
 {
     [TestFixture]
     [Category("Integration")]
+    [Category("Integration_DB")]
     [Explicit]
-    public class CourseDbContextIntegrationTests
+    public class CourseDbContextIntegrationTests : CourseDbContextIntegrationBase
     {
-        private CourseDbContext context;
-
-        private IList<EntityEntry> entitiesToCleanUp = new List<EntityEntry>();
-
-        public CourseDbContext GetContext()
-        {
-            var config = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("integration-tests.json")
-                .Build();            
-
-            var options = new DbContextOptionsBuilder<CourseDbContext>()
-                .UseNpgsql(new EnvConfigConnectionStringBuilder().GetConnectionString(config))
-                .Options;                
-
-            return new CourseDbContext(options);             
-        }
-
-        [OneTimeSetUp]
-        public void SetUpFixture()
-        {
-            context = GetContext();
-            context.Database.EnsureDeleted();
-            context.Database.Migrate();
-        }
-
-        [SetUp]
-        public void SetUp()
-        {
-            context = GetContext();
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            if (entitiesToCleanUp.Any())
-            {
-                foreach (var e in entitiesToCleanUp)
-                {
-                    e.State = EntityState.Deleted;
-                }
-                entitiesToCleanUp.Clear();
-                context.SaveChanges();
-            }
-        }
-
-        [OneTimeTearDown]
-        public void TearDownFixture()
-        {
-            context = GetContext();
-            context.Database.EnsureDeleted();
-        }
-
-        [Test]
-        public void EnsureCreated()
-        {
-            Assert.False(context.Database.EnsureCreated());
-        }
-        
         [Test]
         public void InsertCourse()
         {
@@ -84,11 +26,11 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.DatabaseAccess
             var entity = context.Courses.Add(GetSimpleCourse());
             context.SaveChanges();
             entitiesToCleanUp.Add(entity);
-            
-            using (var context2 = GetContext()) 
+
+            using (var context2 = GetContext())
             {
                 var allCourses = context2.Courses.FromSql("SELECT *, NULL as \"Distance\" FROM \"course\"");
-                
+
                 Assert.AreEqual(1, allCourses.Count());
                 Assert.AreEqual(GetSimpleCourse().Name, allCourses.First().Name);
             }
@@ -104,11 +46,11 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.DatabaseAccess
             context.SaveChanges();
             entitiesToCleanUp.Add(entity);
 
-            using (var context2 = GetContext()) 
+            using (var context2 = GetContext())
             {
                 Assert.AreEqual(1, context2.GetLocationFilteredCourses(50, 0, 1000).Count(), "Filtered to (roughly) London, the course should be found");
                 Assert.AreEqual(0, context2.GetLocationFilteredCourses(56.0, -3.2, 1000).Count(), "Filtered to (roughly) Edinburgh, the course shouldn't be found");
-                
+
                 var distance = context2.GetLocationFilteredCourses(50, 0.01, 1000).Single().Distance;
                 Assert.NotNull(distance);
                 Assert.LessOrEqual(715, distance.Value);
@@ -145,7 +87,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.DatabaseAccess
             context.SaveChanges();
             entitiesToCleanUp.Add(entity);
 
-            using (var context2 = GetContext()) 
+            using (var context2 = GetContext())
             {
                 Assert.AreEqual(1, context2.GetTextFilteredCourses("Provider").Count(), "Filtered to a text string that exists, the course should be found");
                 Assert.AreEqual(1, context2.GetTextFilteredCourses("Provider's").Count(), "Even with single quote and plural, it works");
@@ -166,7 +108,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.DatabaseAccess
             context.SaveChanges();
             entitiesToCleanUp.Add(entity);
 
-            using (var context2 = GetContext()) 
+            using (var context2 = GetContext())
             {
                 Assert.Throws(typeof(ArgumentException), () => context2.GetTextFilteredCourses(""), "Empty");
                 Assert.Throws(typeof(ArgumentException), () => context2.GetTextFilteredCourses("  "), "Whitespace");
@@ -176,7 +118,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.DatabaseAccess
                 Assert.Throws(typeof(ArgumentException), () => context2.GetTextAndLocationFilteredCourses(null, 50, 0, 1000), "Null (with location)");
             }
         }
-        
+
         [Test]
         public void ProviderSuggest()
         {
@@ -186,7 +128,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.DatabaseAccess
             context.SaveChanges();
             entitiesToCleanUp.Add(entity);
 
-            using (var context2 = GetContext()) 
+            using (var context2 = GetContext())
             {
                 Assert.AreEqual(1, context2.SuggestProviders("prov").Count(), "incomplete");
                 Assert.AreEqual(1, context2.SuggestProviders("provider").Count(), "complete");
@@ -214,7 +156,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.DatabaseAccess
                     Latitude = 50.0,
                     Longitude = 0
                 },
-                Campuses = new HashSet<Campus> 
+                Campuses = new HashSet<Campus>
                 {
                     new Campus { Name = "My Campus" }
                 },

--- a/tests/Integration.Tests/UcasLink/UcasCourseDbContextIntegrationTests.cs
+++ b/tests/Integration.Tests/UcasLink/UcasCourseDbContextIntegrationTests.cs
@@ -126,13 +126,31 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.UcasLink
                     Name = "My provider",
                     ProviderCode = "ProviderCode"
                 },
+                ProviderLocation = new Location
+                {
+                    Address = "123 Fake Street",
+                    Latitude = 50.0,
+                    Longitude = 0
+                },
+                Campuses = new HashSet<Campus>
+                {
+                    new Campus { Name = "My Campus" }
+                },
+                CourseSubjects = new HashSet<CourseSubject>
+                {
+                    new CourseSubject { Subject = new Subject {Name = "My subject"} }
+                },
                 Route = new Route
                 {
                     Name = "SCITT"
                 },
-                // IsSalaried = false,
+                IsSalaried = false,
                 Fees = new Fees { Eu = 9250, Uk = 9250, International = 16340 },
-                // Salary = new Salary()
+                Salary = new Salary(),
+                DescriptionSections = new HashSet<CourseDescriptionSection>
+                    {
+                        new CourseDescriptionSection { Name= "CourseDescriptionSection"}
+                    }
             };
         }
     }

--- a/tests/Integration.Tests/UcasLink/UcasCourseDbContextIntegrationTests.cs
+++ b/tests/Integration.Tests/UcasLink/UcasCourseDbContextIntegrationTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using GovUk.Education.SearchAndCompare.Api.Controllers;
+using GovUk.Education.SearchAndCompare.Api.DatabaseAccess;
+using GovUk.Education.SearchAndCompare.Domain.Models;
+using GovUk.Education.SearchAndCompare.Domain.Models.Joins;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.UcasLink
+{
+    [TestFixture]
+    [Category("Integration")]
+    [Category("Integration_Ucas")]
+    [Explicit]
+    public class UcasCourseDbContextIntegrationTests
+    {
+        // CourseDbContextIntegrationTests extract to base class [start]
+        private CourseDbContext context;
+
+        private IList<EntityEntry> entitiesToCleanUp = new List<EntityEntry>();
+
+        public CourseDbContext GetContext()
+        {
+            var config = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("integration-tests.json")
+                .Build();
+
+            var options = new DbContextOptionsBuilder<CourseDbContext>()
+                .UseNpgsql(new EnvConfigConnectionStringBuilder().GetConnectionString(config))
+                .Options;
+
+            return new CourseDbContext(options);
+        }
+
+        [OneTimeSetUp]
+        public void SetUpFixture()
+        {
+            context = GetContext();
+            context.Database.EnsureDeleted();
+            context.Database.Migrate();
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            context = GetContext();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (entitiesToCleanUp.Any())
+            {
+                foreach (var e in entitiesToCleanUp)
+                {
+                    e.State = EntityState.Deleted;
+                }
+                entitiesToCleanUp.Clear();
+                context.SaveChanges();
+            }
+        }
+
+        [OneTimeTearDown]
+        public void TearDownFixture()
+        {
+            context = GetContext();
+            context.Database.EnsureDeleted();
+        }
+
+        [Test]
+        public void EnsureCreated()
+        {
+            Assert.False(context.Database.EnsureCreated());
+        }
+        // CourseDbContextIntegrationTests extract to base class [end]
+
+
+        [Test]
+        public void InsertCourse()
+        {
+            Assert.AreEqual(0, context.Courses.Count());
+
+            var entity = context.Courses.Add(GetMinimalCourse());
+            context.SaveChanges();
+            entitiesToCleanUp.Add(entity);
+
+            using (var context2 = GetContext())
+            {
+                var allCourses = context2.Courses.FromSql("SELECT *, NULL as \"Distance\" FROM \"course\"");
+
+                Assert.AreEqual(1, allCourses.Count());
+                Assert.AreEqual(GetMinimalCourse().Name, allCourses.First().Name);
+                Assert.AreEqual(1, allCourses.First().Id);
+
+            }
+        }
+
+        [Test]
+        public void UcasController_GetUcasCourseUrl()
+        {
+
+            var subject = new UcasController(GetContext(), new HttpClient());
+
+            var actual = subject.GetUcasCourseUrl(1).Result;
+
+
+
+        }
+
+
+        private static Course GetMinimalCourse()
+        {
+            return new Course()
+            {
+                Name = "My minimal course",
+                ProgrammeCode = "ProgrammeCode",
+                Provider = new Provider
+                {
+                    Name = "My provider",
+                    ProviderCode = "ProviderCode"
+                },
+                Route = new Route
+                {
+                    Name = "SCITT"
+                },
+                // IsSalaried = false,
+                Fees = new Fees { Eu = 9250, Uk = 9250, International = 16340 },
+                // Salary = new Salary()
+            };
+        }
+    }
+}

--- a/tests/Integration.Tests/UcasLink/UcasCourseDbContextIntegrationTests.cs
+++ b/tests/Integration.Tests/UcasLink/UcasCourseDbContextIntegrationTests.cs
@@ -13,6 +13,7 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
 using GovUk.Education.SearchAndCompare.Api.Integration.Tests.DatabaseAccess;
+using Microsoft.Extensions.Options;
 
 namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.UcasLink
 {
@@ -47,12 +48,13 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.UcasLink
 
             var courseId = context.Courses.FromSql("SELECT *, NULL as \"Distance\" FROM \"course\"").First().Id;
 
-            var ucasSettings = new UcasSettings
+            var ucasSettings = Options.Create<UcasSettings>( new UcasSettings
             {
                 GenerateCourseUrlFormat = @"http://search.gttr.ac.uk/cgi-bin/hsrun.hse/General/2018_gttr_search/StateId/{3}/HAHTpage/gttr_search.HsProfile.run?inst={0}&course={1}&mod={2}",
                 SearchStartUrl = "http://search.gttr.ac.uk/cgi-bin/hsrun.hse/General/2018_gttr_search/gttr_search.hjx;start=gttr_search.HsForm.run",
                 ExtractStateIdRegex = @"StateId\/([^\/]*)\/"
-            };
+            });
+
 
             var subject = new UcasController(ucasSettings, GetContext(), new HttpClient());
 
@@ -61,7 +63,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.UcasLink
             Assert.IsTrue(actual.StatusCode == 200);
 
             var expectedCourse = GetMinimalCourse();
-            var url = actual.Value as string;
+            var url = actual.Value.GetType().GetProperty("courseUrl").GetValue(actual.Value, null) as string;
             Assert.NotNull(url);
 
             StringAssert.Contains(expectedCourse.ProgrammeCode, url);


### PR DESCRIPTION
Aside from the modifier which is currently hard-coded, this PR provides the ability to:

* get a new sessionId from the UCAS site
* build a URL for a course on the UCAS site (which will only be valid till the session expires)

Once this is merged and the nuget package updated we'll do a PR for the [UI project branch](https://github.com/DFE-Digital/search-and-compare-ui/commits/ucas-link) that makes use of this.

-----

This code is not yet well factored etc, but is a usable increment which can then be improved upon.
Feedback on the style of the PR welcome as we want to improve our balance of raw coding speed versus wider team interactions.