### PR TITLE
use (case insensitive) course codes in S+C URLs

### DIFF
--- a/src/api/Controllers/CoursesController.cs
+++ b/src/api/Controllers/CoursesController.cs
@@ -80,10 +80,10 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
         }
 
         // GET api/courses/{id}
-        [HttpGet("{courseId:int}")]
-        public async Task<IActionResult> GetById(int courseId)
+        [HttpGet("{courseCode:string}")]
+        public async Task<IActionResult> GetByCourseCode(string courseCode)
         {
-            var course = await _context.GetCourseWithProviderSubjectsRouteCampusesAndDescriptions(courseId);
+            var course = await _context.GetCourseWithProviderSubjectsRouteCampusesAndDescriptions(courseCode);
 
             return Ok(course);
         }

--- a/src/api/Controllers/CoursesController.cs
+++ b/src/api/Controllers/CoursesController.cs
@@ -80,10 +80,10 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
         }
 
         // GET api/courses/{id}
-        [HttpGet("{courseCode:string}")]
-        public async Task<IActionResult> GetByCourseCode(string courseCode)
+        [HttpGet("{providerCode:string}/{courseCode:string}")]
+        public async Task<IActionResult> GetByCourseCode(string providerCode, string courseCode)
         {
-            var course = await _context.GetCourseWithProviderSubjectsRouteCampusesAndDescriptions(courseCode);
+            var course = await _context.GetCourseWithProviderSubjectsRouteCampusesAndDescriptions(providerCode, courseCode);
 
             return Ok(course);
         }

--- a/src/api/Controllers/UcasController.cs
+++ b/src/api/Controllers/UcasController.cs
@@ -24,10 +24,10 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
         /// Get a valid sessionId from the ucas site and then return a url for the course.
         /// The url will only be valid while the session is valid! (5 mins at last test)
         /// </summary>
-        [HttpGet("course-url/{courseId:int}")]
-        public async Task<IActionResult> GetUcasCourseUrl(int courseId)
+        [HttpGet("course-url/{courseCode:string}")]
+        public async Task<IActionResult> GetUcasCourseUrl(string courseCode)
         {
-            var course =  await _context.GetCourseWithProviderSubjectsRouteCampusesAndDescriptions(courseId);
+            var course =  await _context.GetCourseWithProviderSubjectsRouteCampusesAndDescriptions(courseCode);
 
             if (course == null){
                 return NotFound();

--- a/src/api/Controllers/UcasController.cs
+++ b/src/api/Controllers/UcasController.cs
@@ -24,10 +24,10 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
         /// Get a valid sessionId from the ucas site and then return a url for the course.
         /// The url will only be valid while the session is valid! (5 mins at last test)
         /// </summary>
-        [HttpGet("course-url/{courseCode:string}")]
-        public async Task<IActionResult> GetUcasCourseUrl(string courseCode)
+        [HttpGet("course-url/{providerCode:string}/{courseCode:string}")]
+        public async Task<IActionResult> GetUcasCourseUrl(string providerCode, string courseCode)
         {
-            var course =  await _context.GetCourseWithProviderSubjectsRouteCampusesAndDescriptions(courseCode);
+            var course =  await _context.GetCourseWithProviderSubjectsRouteCampusesAndDescriptions(providerCode, courseCode);
 
             if (course == null){
                 return NotFound();

--- a/src/api/DatabaseAccess/CourseDbContext.cs
+++ b/src/api/DatabaseAccess/CourseDbContext.cs
@@ -116,19 +116,22 @@ JOIN ""course"" on ""course"".""Id"" = ""c1"".""Id""",
 
         public IQueryable<Course> GetCoursesWithProviderSubjectsRouteAndCampuses()
         {
-            return ForListing(Courses.FromSql("SELECT *, NULL as \"Distance\" FROM \"course\""));
+            return GetCoursesWithProviderSubjectsRouteAndCampuses(null);
         }
-
-        public IQueryable<Course> GetCoursesWithProviderSubjectsRouteCampusesAndDescriptions()
+        
+        public async Task<Course> GetCourseWithProviderSubjectsRouteCampusesAndDescriptions(string courseCode)
         {
-            return GetCoursesWithProviderSubjectsRouteAndCampuses()
-                .Include(x => x.DescriptionSections);
+            return await GetCoursesWithProviderSubjectsRouteAndCampuses(courseCode)
+                .Include(x => x.DescriptionSections).FirstAsync();
         }
-
-        public async Task<Course> GetCourseWithProviderSubjectsRouteCampusesAndDescriptions(int courseId)
+        
+        private IQueryable<Course> GetCoursesWithProviderSubjectsRouteAndCampuses(string courseCode)
         {
-            return await GetCoursesWithProviderSubjectsRouteCampusesAndDescriptions()
-                .Where(c => c.Id == courseId).FirstAsync();
+            var whereClause = string.IsNullOrWhiteSpace(courseCode)
+                ? ""
+                : " WHERE lower(\"ProgrammeCode\") = lower(@coursecode)";
+
+            return ForListing(Courses.FromSql("SELECT *, NULL as \"Distance\" FROM \"course\"" + whereClause, new NpgsqlParameter("@coursecode", courseCode)));
         }
 
         public IQueryable<Subject> GetSubjects()

--- a/src/api/DatabaseAccess/ICourseDbContext.cs
+++ b/src/api/DatabaseAccess/ICourseDbContext.cs
@@ -33,7 +33,7 @@ namespace GovUk.Education.SearchAndCompare.Api.DatabaseAccess
 
         IQueryable<Course> GetCoursesWithProviderSubjectsRouteAndCampuses();
 
-        Task<Course> GetCourseWithProviderSubjectsRouteCampusesAndDescriptions(string courseCode);
+        Task<Course> GetCourseWithProviderSubjectsRouteCampusesAndDescriptions(string providerCode, string courseCode);
 
         IQueryable<Subject> GetSubjects();
 

--- a/src/api/DatabaseAccess/ICourseDbContext.cs
+++ b/src/api/DatabaseAccess/ICourseDbContext.cs
@@ -33,9 +33,7 @@ namespace GovUk.Education.SearchAndCompare.Api.DatabaseAccess
 
         IQueryable<Course> GetCoursesWithProviderSubjectsRouteAndCampuses();
 
-        IQueryable<Course> GetCoursesWithProviderSubjectsRouteCampusesAndDescriptions();
-
-        Task<Course> GetCourseWithProviderSubjectsRouteCampusesAndDescriptions(int courseId);
+        Task<Course> GetCourseWithProviderSubjectsRouteCampusesAndDescriptions(string courseCode);
 
         IQueryable<Subject> GetSubjects();
 

--- a/src/domain/Client/IHttpClient.cs
+++ b/src/domain/Client/IHttpClient.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace GovUk.Education.SearchAndCompare.Domain.Client
+{
+    public interface IHttpClient
+    {
+        Task<HttpResponseMessage> GetAsync(Uri queryUri);
+    }
+
+    public class HttpClientWrapper : IHttpClient
+    {
+        private readonly HttpClient wrapped;
+
+        public HttpClientWrapper(HttpClient wrapped)
+        {
+            this.wrapped = wrapped;
+        }
+
+        public Task<HttpResponseMessage> GetAsync(Uri queryUri)
+        {
+            return wrapped.GetAsync(queryUri);
+        }
+    }
+}

--- a/src/domain/Client/ISearchAndCompareApi.cs
+++ b/src/domain/Client/ISearchAndCompareApi.cs
@@ -8,7 +8,7 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
 {
     public interface ISearchAndCompareApi
     {
-        Course GetCourse(int courseId);
+        Course GetCourse(string courseCode);
 
         PaginatedList<Course> GetCourses(QueryFilter filter);
         TotalCountResult GetCoursesTotalCount(QueryFilter filter);
@@ -21,6 +21,6 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
 
         List<Provider> GetProviderSuggestions(string query);
 
-        string GetUcasCourseUrl(int courseId);
+        string GetUcasCourseUrl(string courseCode);
     }
 }

--- a/src/domain/Client/ISearchAndCompareApi.cs
+++ b/src/domain/Client/ISearchAndCompareApi.cs
@@ -8,7 +8,7 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
 {
     public interface ISearchAndCompareApi
     {
-        Course GetCourse(string courseCode);
+        Course GetCourse(string providerCode, string courseCode);
 
         PaginatedList<Course> GetCourses(QueryFilter filter);
         TotalCountResult GetCoursesTotalCount(QueryFilter filter);
@@ -21,6 +21,6 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
 
         List<Provider> GetProviderSuggestions(string query);
 
-        string GetUcasCourseUrl(string courseCode);
+        string GetUcasCourseUrl(string providerCode, string courseCode);
     }
 }

--- a/src/domain/Client/SearchAndCompareApi.cs
+++ b/src/domain/Client/SearchAndCompareApi.cs
@@ -31,7 +31,7 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
 
         public Course GetCourse(string providerCode, string courseCode)
         {
-            var queryUri = GetUri(string.Format("/courses/{0}/{1}", providerCode), null);
+            var queryUri = GetUri(string.Format("/courses/{0}/{1}", providerCode, courseCode), null);
 
             return GetObjects<Course>(queryUri);
         }

--- a/src/domain/Client/SearchAndCompareApi.cs
+++ b/src/domain/Client/SearchAndCompareApi.cs
@@ -14,20 +14,24 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
 {
     public class SearchAndCompareApi : ISearchAndCompareApi
     {
-        private readonly HttpClient _httpClient;
+        private readonly IHttpClient _httpClient;
 
         private readonly string _apiUri;
 
-        public SearchAndCompareApi(HttpClient httpClient, string apiUri)
+        public SearchAndCompareApi(HttpClient httpClient, string apiUri) : this (new HttpClientWrapper(httpClient), apiUri)
+        {
+        }
+
+        public SearchAndCompareApi(IHttpClient httpClient, string apiUri)
         {
             _httpClient = httpClient;
             _apiUri = apiUri;
             if (_apiUri.EndsWith('/')) { _apiUri = _apiUri.Remove(_apiUri.Length - 1); }
         }
 
-        public Course GetCourse(int courseId)
+        public Course GetCourse(string courseCode)
         {
-            var queryUri = GetUri(string.Format("/courses/{0}", courseId), null);
+            var queryUri = GetUri(string.Format("/courses/{0}", courseCode), null);
 
             return GetObjects<Course>(queryUri);
         }
@@ -76,9 +80,9 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
             return GetObjects<List<Provider>>(buider.Uri) ?? new List<Provider>();
         }
 
-        public string GetUcasCourseUrl(int courseId)
+        public string GetUcasCourseUrl(string courseCode)
         {
-            var queryUri = GetUri(string.Format("/ucas/course-url/{0}", courseId), null);
+            var queryUri = GetUri(string.Format("/ucas/course-url/{0}", courseCode), null);
 
             dynamic result =  GetObjects<JObject>(queryUri);;
 
@@ -101,7 +105,8 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
         {
             var uri = new Uri(_apiUri);
             var builder = new UriBuilder(uri);
-            if (!apiPath.StartsWith('/')) { builder.Path += '/'; }
+            if (!builder.Path.EndsWith('/') && !apiPath.StartsWith('/')) { builder.Path += '/'; }
+            else if (builder.Path.EndsWith('/') && apiPath.StartsWith('/')) { apiPath = apiPath.Substring(1); }
             builder.Path += apiPath;
             if (filter != null) { builder.Query = filter.AsQueryString(); }
             return builder.Uri;

--- a/src/domain/Client/SearchAndCompareApi.cs
+++ b/src/domain/Client/SearchAndCompareApi.cs
@@ -29,9 +29,9 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
             if (_apiUri.EndsWith('/')) { _apiUri = _apiUri.Remove(_apiUri.Length - 1); }
         }
 
-        public Course GetCourse(string courseCode)
+        public Course GetCourse(string providerCode, string courseCode)
         {
-            var queryUri = GetUri(string.Format("/courses/{0}", courseCode), null);
+            var queryUri = GetUri(string.Format("/courses/{0}/{1}", providerCode), null);
 
             return GetObjects<Course>(queryUri);
         }
@@ -80,9 +80,9 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
             return GetObjects<List<Provider>>(buider.Uri) ?? new List<Provider>();
         }
 
-        public string GetUcasCourseUrl(string courseCode)
+        public string GetUcasCourseUrl(string providerCode, string courseCode)
         {
-            var queryUri = GetUri(string.Format("/ucas/course-url/{0}", courseCode), null);
+            var queryUri = GetUri(string.Format("/ucas/course-url/{0}/{1}", providerCode, courseCode), null);
 
             dynamic result =  GetObjects<JObject>(queryUri);;
 

--- a/src/domain/SearchAndCompareDomain.csproj
+++ b/src/domain/SearchAndCompareDomain.csproj
@@ -6,7 +6,7 @@
     <Authors>DfE Digital</Authors>
     <Title>Domain objects for SearchAndCompare project</Title>
     <Description>Domain objects for SearchAndCompare project</Description>
-    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionPrefix>0.6.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <RootNamespace>GovUk.Education.SearchAndCompare.Domain</RootNamespace>
   </PropertyGroup>

--- a/src/domain/SearchAndCompareDomain.csproj
+++ b/src/domain/SearchAndCompareDomain.csproj
@@ -6,7 +6,7 @@
     <Authors>DfE Digital</Authors>
     <Title>Domain objects for SearchAndCompare project</Title>
     <Description>Domain objects for SearchAndCompare project</Description>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <RootNamespace>GovUk.Education.SearchAndCompare.Domain</RootNamespace>
   </PropertyGroup>

--- a/tests/Integration.Tests/DatabaseAccess/CourseDbContextIntegrationTests.cs
+++ b/tests/Integration.Tests/DatabaseAccess/CourseDbContextIntegrationTests.cs
@@ -148,7 +148,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.DatabaseA
 
             using (var context2 = GetContext())
             {
-                var course = context2.GetCourseWithProviderSubjectsRouteCampusesAndDescriptions("1aB").Result;
+                var course = context2.GetCourseWithProviderSubjectsRouteCampusesAndDescriptions("xYz", "1aB").Result;
                 Assert.AreEqual("1AB", course.ProgrammeCode, "course code is retrieved");
                 Assert.AreEqual("My first course", course.Name, "course name is retrieved");
 
@@ -161,7 +161,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.DatabaseA
                 Assert.AreEqual("Content", course.DescriptionSections.Single().Text, "description content is retrieved");
             }
         }
-        
+
         private static Course GetSimpleCourse()
         {
             return new Course()
@@ -172,6 +172,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.DatabaseA
 
                 Provider = new Provider
                 {
+                    ProviderCode = "XYZ",
                     Name = "My provider"
                 },
                 ProviderLocation = new Location

--- a/tests/Integration.Tests/DatabaseAccess/CourseDbContextIntegrationTests.cs
+++ b/tests/Integration.Tests/DatabaseAccess/CourseDbContextIntegrationTests.cs
@@ -135,13 +135,41 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.DatabaseA
                 Assert.AreEqual(1, context2.SuggestProviders("provider my").Count(), "multiwords good");
                 Assert.AreEqual(1, context2.SuggestProviders("prov my").Count(), "multiwords good incomplete");
             }
-
         }
+
+        [Test]
+        public void RetrieveByIdCaseInsenstive()
+        {
+            Assert.AreEqual(0, context.Courses.Count());
+
+            var entity = context.Courses.Add(GetSimpleCourse());
+            context.SaveChanges();
+            entitiesToCleanUp.Add(entity);
+
+            using (var context2 = GetContext())
+            {
+                var course = context2.GetCourseWithProviderSubjectsRouteCampusesAndDescriptions("1aB").Result;
+                Assert.AreEqual("1AB", course.ProgrammeCode, "course code is retrieved");
+                Assert.AreEqual("My first course", course.Name, "course name is retrieved");
+
+                Assert.AreEqual("My Campus", course.Campuses.Single().Name, "campus data is retrieved");
+                Assert.AreEqual("SCITT", course.Route.Name, "route data is retrieved");
+                Assert.AreEqual("My subject", course.CourseSubjects.Single().Subject.Name, "subject data is retrieved");
+                Assert.AreEqual("My Campus", course.Campuses.Single().Name, "campus data is retrieved");
+
+                Assert.AreEqual("Title", course.DescriptionSections.Single().Name, "description title is retrieved");
+                Assert.AreEqual("Content", course.DescriptionSections.Single().Text, "description content is retrieved");
+            }
+        }
+        
         private static Course GetSimpleCourse()
         {
             return new Course()
             {
                 Name = "My first course",
+
+                ProgrammeCode = "1AB",
+
                 Provider = new Provider
                 {
                     Name = "My provider"
@@ -166,7 +194,11 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.DatabaseA
                 },
                 IsSalaried = false,
                 Fees = new Fees { Eu = 9250, Uk = 9250, International = 16340 },
-                Salary = new Salary()
+                Salary = new Salary(),
+                DescriptionSections = new HashSet<CourseDescriptionSection>
+                {
+                    new CourseDescriptionSection { Id = 1, Name = "Title", Text = "Content" }
+                }
             };
         }
     }

--- a/tests/Unit.Tests/Client/SearchAndCompareApi.Tests.cs
+++ b/tests/Unit.Tests/Client/SearchAndCompareApi.Tests.cs
@@ -24,14 +24,14 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Unit.Tests.Client
         [Test]
         public void GetCourse_CallsCorrectUrl()
         {
-            mockHttp.Setup(x => x.GetAsync(It.Is<Uri>(y => y.AbsoluteUri == "https://api.example.com/courses/1AB"))).ReturnsAsync(
+            mockHttp.Setup(x => x.GetAsync(It.Is<Uri>(y => y.AbsoluteUri == "https://api.example.com/courses/XYZ/1AB"))).ReturnsAsync(
                 new HttpResponseMessage() {
                     StatusCode = HttpStatusCode.OK,
                     Content = new ByteArrayContent(Encoding.UTF8.GetBytes(@"{""Name"": ""My first course""}"))
                 }
             ).Verifiable();
 
-            var result = sut.GetCourse("1AB");
+            var result = sut.GetCourse("XYZ", "1AB");
 
             Assert.AreEqual("My first course", result.Name);
             mockHttp.VerifyAll();
@@ -40,14 +40,14 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Unit.Tests.Client
         [Test]
         public void GetUcasCourseUrl_CallsCorrectUrl()
         {
-            mockHttp.Setup(x => x.GetAsync(It.Is<Uri>(y => y.AbsoluteUri == "https://api.example.com/ucas/course-url/1AB"))).ReturnsAsync(
+            mockHttp.Setup(x => x.GetAsync(It.Is<Uri>(y => y.AbsoluteUri == "https://api.example.com/ucas/course-url/XYZ/1AB"))).ReturnsAsync(
                 new HttpResponseMessage() {
                     StatusCode = HttpStatusCode.OK,
                     Content = new ByteArrayContent(Encoding.UTF8.GetBytes(@"{""courseUrl"": ""http://ucas.com""}"))
                 }
             ).Verifiable();
 
-            var result = sut.GetUcasCourseUrl("1AB");
+            var result = sut.GetUcasCourseUrl("XYZ", "1AB");
 
             Assert.AreEqual("http://ucas.com", result);
             mockHttp.VerifyAll();

--- a/tests/Unit.Tests/Client/SearchAndCompareApi.Tests.cs
+++ b/tests/Unit.Tests/Client/SearchAndCompareApi.Tests.cs
@@ -1,3 +1,9 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using GovUk.Education.SearchAndCompare.Domain.Client;
+using Moq;
 using NUnit.Framework;
 
 namespace GovUk.Education.SearchAndCompare.Api.Tests.Unit.Tests.Client
@@ -5,18 +11,46 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Unit.Tests.Client
     [TestFixture]
     public class SearchAndCompareApiTests
     {
-        [TestFixture]
-        public class GetAllTests
+        private SearchAndCompareApi sut;
+        private Mock<IHttpClient> mockHttp;
+
+        [SetUp]
+        public void SetUp()
         {
-            // [Test]
-            // public void GetCourse()
-            // {
-            //     var api = new SearchAndCompareApi(new HttpClient(), "http://localhost:5000/api");
+            mockHttp = new Mock<IHttpClient>();
+            sut = new SearchAndCompareApi(mockHttp.Object, "https://api.example.com");
+        }
 
-            //     var course = api.GetCourse(1);
+        [Test]
+        public void GetCourse_CallsCorrectUrl()
+        {
+            mockHttp.Setup(x => x.GetAsync(It.Is<Uri>(y => y.AbsoluteUri == "https://api.example.com/courses/1AB"))).ReturnsAsync(
+                new HttpResponseMessage() {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new ByteArrayContent(Encoding.UTF8.GetBytes(@"{""Name"": ""My first course""}"))
+                }
+            ).Verifiable();
 
-            //     var courses = api.GetCourses(new QueryFilter());
-            // }
+            var result = sut.GetCourse("1AB");
+
+            Assert.AreEqual("My first course", result.Name);
+            mockHttp.VerifyAll();
+        }
+                
+        [Test]
+        public void GetUcasCourseUrl_CallsCorrectUrl()
+        {
+            mockHttp.Setup(x => x.GetAsync(It.Is<Uri>(y => y.AbsoluteUri == "https://api.example.com/ucas/course-url/1AB"))).ReturnsAsync(
+                new HttpResponseMessage() {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new ByteArrayContent(Encoding.UTF8.GetBytes(@"{""courseUrl"": ""http://ucas.com""}"))
+                }
+            ).Verifiable();
+
+            var result = sut.GetUcasCourseUrl("1AB");
+
+            Assert.AreEqual("http://ucas.com", result);
+            mockHttp.VerifyAll();
         }
     }
 }


### PR DESCRIPTION
### Context

https://trello.com/c/NyS5Xcy3/51-persistent-urls-in-search-and-compare-using-course-code

### Changes proposed in this pull request

Change UCAS-URL and Course details endpoints in API to accept course codes and find (case-insensitively) the matching course.

Bump API Client version number as this is a breaking change

Optionally instantiate S+C API client with a wrapper around HttpClient to make unit testing possible.


### Guidance to review

See tests and refer to corresponding UI pull request