### PR TITLE
bugfix: malformed course URLs

### DIFF
--- a/src/domain/Client/ISearchAndCompareApi.cs
+++ b/src/domain/Client/ISearchAndCompareApi.cs
@@ -20,7 +20,5 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
         List<FeeCaps> GetFeeCaps();
 
         List<Provider> GetProviderSuggestions(string query);
-
-        string GetUcasCourseUrl(string providerCode, string courseCode);
     }
 }

--- a/src/domain/Client/SearchAndCompareApi.cs
+++ b/src/domain/Client/SearchAndCompareApi.cs
@@ -31,7 +31,7 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
 
         public Course GetCourse(string providerCode, string courseCode)
         {
-            var queryUri = GetUri(string.Format("/courses/{0}/{1}", providerCode, courseCode), null);
+            var queryUri = GetUri($"/courses/{providerCode}/{courseCode}");
 
             return GetObjects<Course>(queryUri);
         }
@@ -52,21 +52,21 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
 
         public List<Subject> GetSubjects()
         {
-            var queryUri = GetUri("/subjects", null);
+            var queryUri = GetUri("/subjects");
 
             return GetObjects<List<Subject>>(queryUri);
         }
 
         public List<SubjectArea> GetSubjectAreas()
         {
-            var queryUri = GetUri("/subjectareas", null);
+            var queryUri = GetUri("/subjectareas");
 
             return GetObjects<List<SubjectArea>>(queryUri);
         }
 
         public List<FeeCaps> GetFeeCaps()
         {
-            var queryUri = GetUri("/feecaps", null);
+            var queryUri = GetUri("/feecaps");
 
             return GetObjects<List<FeeCaps>>(queryUri);
         }
@@ -78,15 +78,6 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
             buider.Query = "query=" + HttpUtility.UrlEncode(query);
 
             return GetObjects<List<Provider>>(buider.Uri) ?? new List<Provider>();
-        }
-
-        public string GetUcasCourseUrl(string providerCode, string courseCode)
-        {
-            var queryUri = GetUri(string.Format("/ucas/course-url/{0}/{1}", providerCode, courseCode), null);
-
-            dynamic result =  GetObjects<JObject>(queryUri);;
-
-            return result.courseUrl;
         }
 
         private T GetObjects<T>(Uri queryUri)
@@ -101,7 +92,7 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
             return objects;
         }
 
-        private Uri GetUri(string apiPath, QueryFilter filter)
+        private Uri GetUri(string apiPath, QueryFilter filter = null)
         {
             var uri = new Uri(_apiUri);
             var builder = new UriBuilder(uri);

--- a/src/domain/SearchAndCompareDomain.csproj
+++ b/src/domain/SearchAndCompareDomain.csproj
@@ -6,7 +6,7 @@
     <Authors>DfE Digital</Authors>
     <Title>Domain objects for SearchAndCompare project</Title>
     <Description>Domain objects for SearchAndCompare project</Description>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionPrefix>0.6.1</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <RootNamespace>GovUk.Education.SearchAndCompare.Domain</RootNamespace>
   </PropertyGroup>

--- a/tests/Unit.Tests/Client/SearchAndCompareApi.Tests.cs
+++ b/tests/Unit.Tests/Client/SearchAndCompareApi.Tests.cs
@@ -36,21 +36,5 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Unit.Tests.Client
             Assert.AreEqual("My first course", result.Name);
             mockHttp.VerifyAll();
         }
-                
-        [Test]
-        public void GetUcasCourseUrl_CallsCorrectUrl()
-        {
-            mockHttp.Setup(x => x.GetAsync(It.Is<Uri>(y => y.AbsoluteUri == "https://api.example.com/ucas/course-url/XYZ/1AB"))).ReturnsAsync(
-                new HttpResponseMessage() {
-                    StatusCode = HttpStatusCode.OK,
-                    Content = new ByteArrayContent(Encoding.UTF8.GetBytes(@"{""courseUrl"": ""http://ucas.com""}"))
-                }
-            ).Verifiable();
-
-            var result = sut.GetUcasCourseUrl("XYZ", "1AB");
-
-            Assert.AreEqual("http://ucas.com", result);
-            mockHttp.VerifyAll();
-        }
     }
 }


### PR DESCRIPTION
### Context

Results page -> Course page linking wasn't working

### Changes proposed in this pull request

Make it work.

As a side effect, I've also taken out the unused UCAS URL generator from the API

### Guidance to review

n/a

