### PR TITLE
Fixed ef core issues with entity tracking

### DIFF
--- a/src/api/DatabaseAccess/CourseDbContext.cs
+++ b/src/api/DatabaseAccess/CourseDbContext.cs
@@ -135,7 +135,10 @@ JOIN ""course"" on ""course"".""Id"" = ""c1"".""Id""",
 
         public async Task AddOrUpdateCourse(Course itemToSave)
         {
-            var existingCourse = await GetCourses(itemToSave.Provider.ProviderCode, itemToSave.ProgrammeCode).FirstOrDefaultAsync();
+            var existingCourse = await GetCourses(itemToSave.Provider.ProviderCode, itemToSave.ProgrammeCode)
+            // Note: added course subjects as lack of it causes ef core tracking issues (ie added source and update with same data cause it to add course subject rather than update it)
+            .Include(x => x.CourseSubjects)
+            .FirstOrDefaultAsync();
 
             if(existingCourse == null)
             {


### PR DESCRIPTION
### Context
When updating a course, the course's course subject is also need, to allow for ef to keep that that its either adding something new or updating.

### Changes proposed in this pull request
Ensure that that the course subject is also loaded to let ef core do its work properly

### Guidance to review
Import an existing course
