### PR TITLE
Ef core issues

### DIFF
--- a/src/api/Controllers/CoursesController.cs
+++ b/src/api/Controllers/CoursesController.cs
@@ -59,7 +59,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
                     AssociateWithLocations(ref courses);
                     AssociateWithSubjects(ref courses);
 
-                    ResolveSalaryReferences(ref courses);
+                    ResolveSalaryAndFeesReferences(ref courses);
                     var itemToSave = courses.First();
 
                     await _context.AddOrUpdateCourse(itemToSave);
@@ -449,7 +449,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
             }
         }
 
-        private void ResolveSalaryReferences(ref IList<Course> courses)
+        private void ResolveSalaryAndFeesReferences(ref IList<Course> courses)
         {
             // Even if there is no salary create a new instance to satisfy ef core.
             // The 'course' table is shared with 'Fees' &'Salary' & 'Course' domain object

--- a/src/api/Controllers/CoursesController.cs
+++ b/src/api/Controllers/CoursesController.cs
@@ -117,7 +117,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
                     MakeRoutesDistinctReferences(ref courses);
                     AssociateWithLocations(ref courses);
                     AssociateWithSubjects(ref courses);
-                    ResolveSalaryReferences(ref courses);
+                    ResolveSalaryAndFeesReferences(ref courses);
 
                     _context.Courses.AddRange(courses);
                     _context.SaveChanges();

--- a/src/api/Controllers/CoursesController.cs
+++ b/src/api/Controllers/CoursesController.cs
@@ -58,6 +58,8 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
 
                     AssociateWithLocations(ref courses);
                     AssociateWithSubjects(ref courses);
+
+                    ResolveSalaryReferences(ref courses);
                     var itemToSave = courses.First();
 
                     await _context.AddOrUpdateCourse(itemToSave);
@@ -115,6 +117,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
                     MakeRoutesDistinctReferences(ref courses);
                     AssociateWithLocations(ref courses);
                     AssociateWithSubjects(ref courses);
+                    ResolveSalaryReferences(ref courses);
 
                     _context.Courses.AddRange(courses);
                     _context.SaveChanges();
@@ -443,6 +446,16 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
                 {
                     course.Route = existing.GetValueOrDefault(course.Route.Name) ?? distinctRoutes[course.Route.Name];
                 }
+            }
+        }
+
+        private void ResolveSalaryReferences(ref IList<Course> courses)
+        {
+            // Even if there is no salary create a new instance to satisfy ef core.
+            // The 'course' table is shared with 'Salary' & 'Course' domain object
+            foreach (var course in courses)
+            {
+                course.Salary = course.Salary ?? new Salary();
             }
         }
     }

--- a/src/api/Controllers/CoursesController.cs
+++ b/src/api/Controllers/CoursesController.cs
@@ -452,9 +452,10 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
         private void ResolveSalaryReferences(ref IList<Course> courses)
         {
             // Even if there is no salary create a new instance to satisfy ef core.
-            // The 'course' table is shared with 'Salary' & 'Course' domain object
+            // The 'course' table is shared with 'Fees' &'Salary' & 'Course' domain object
             foreach (var course in courses)
             {
+                course.Fees = course.Fees ?? new Fees();
                 course.Salary = course.Salary ?? new Salary();
             }
         }

--- a/src/api/DatabaseAccess/CourseDbContext.cs
+++ b/src/api/DatabaseAccess/CourseDbContext.cs
@@ -143,6 +143,8 @@ JOIN ""course"" on ""course"".""Id"" = ""c1"".""Id""",
             if(existingCourse == null)
             {
                 itemToSave.Id = 0;
+                itemToSave.Salary = itemToSave.Salary ?? new Salary();
+
                 Courses.Add(itemToSave);
             }
             else

--- a/src/api/DatabaseAccess/CourseDbContext.cs
+++ b/src/api/DatabaseAccess/CourseDbContext.cs
@@ -143,7 +143,6 @@ JOIN ""course"" on ""course"".""Id"" = ""c1"".""Id""",
             if(existingCourse == null)
             {
                 itemToSave.Id = 0;
-                itemToSave.Salary = itemToSave.Salary ?? new Salary();
 
                 Courses.Add(itemToSave);
             }

--- a/tests/Integration.Tests/Controllers/CoursesController.Tests.cs
+++ b/tests/Integration.Tests/Controllers/CoursesController.Tests.cs
@@ -184,6 +184,20 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
         }
 
         [Test]
+        public void ImportCourse_Null_Salary()
+        {
+            var courses = GetCourses(1);
+            foreach (var item in courses)
+            {
+                item.Salary = null;
+            }
+
+            var result = subject.Index(courses);
+
+            AssertOkay(result);
+        }
+
+        [Test]
         public void ImportCourse_Null_ProviderLocation()
         {
             var courses = GetCourses(1);

--- a/tests/Integration.Tests/Controllers/CoursesController.Tests.cs
+++ b/tests/Integration.Tests/Controllers/CoursesController.Tests.cs
@@ -184,6 +184,20 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
         }
 
         [Test]
+        public void ImportCourse_Null_Fees()
+        {
+            var courses = GetCourses(1);
+            foreach (var item in courses)
+            {
+                item.Fees = null;
+            }
+
+            var result = subject.Index(courses);
+
+            AssertOkay(result);
+        }
+
+        [Test]
         public void ImportCourse_Null_Salary()
         {
             var courses = GetCourses(1);

--- a/tests/Integration.Tests/Controllers/SaveSingleCourse_CoursesController.Tests.cs
+++ b/tests/Integration.Tests/Controllers/SaveSingleCourse_CoursesController.Tests.cs
@@ -86,6 +86,21 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
         }
 
         [Test]
+        public async Task ImportCourse_Null_Fees()
+        {
+            var courses = GetCourses(1);
+            foreach (var item in courses)
+            {
+                item.Fees = null;
+            }
+
+            var course = courses.First();
+            var result = await subject.SaveCourse(course.Provider.ProviderCode, course.ProgrammeCode, course);
+
+            AssertOkay(result);
+        }
+
+        [Test]
         public async Task ImportCourse_Null_Salary()
         {
             var courses = GetCourses(1);

--- a/tests/Integration.Tests/Controllers/SaveSingleCourse_CoursesController.Tests.cs
+++ b/tests/Integration.Tests/Controllers/SaveSingleCourse_CoursesController.Tests.cs
@@ -86,6 +86,21 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
         }
 
         [Test]
+        public async Task ImportCourse_Null_Salary()
+        {
+            var courses = GetCourses(1);
+            foreach (var item in courses)
+            {
+                item.Salary = null;
+            }
+
+            var course = courses.First();
+            var result = await subject.SaveCourse(course.Provider.ProviderCode, course.ProgrammeCode, course);
+
+            AssertOkay(result);
+        }
+
+        [Test]
         public async Task ImportCourse_Null_CourseSubjects_Subject()
         {
             var courses = GetCourses(1);


### PR DESCRIPTION
### Context
InvalidOperationException

"The entity of type 'Course' is sharing the table 'course' with entities of type 'Salary', but there is no entity of this type with the same key value that has been marked as 'Added'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values."

### Changes proposed in this pull request

Fix the above exception

### Guidance to review
Uncomment the fix to see exception
