### PR TITLE
Remove unused fields in SubjectFunding

### DIFF
--- a/src/api/Migrations/20180926122323_SimplifySubjectFundingModel.Designer.cs
+++ b/src/api/Migrations/20180926122323_SimplifySubjectFundingModel.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using GovUk.Education.SearchAndCompare.Api.DatabaseAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace SearchAndCompare.Migrations
 {
     [DbContext(typeof(CourseDbContext))]
-    partial class CourseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20180926122323_SimplifySubjectFundingModel")]
+    partial class SimplifySubjectFundingModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/api/Migrations/20180926122323_SimplifySubjectFundingModel.cs
+++ b/src/api/Migrations/20180926122323_SimplifySubjectFundingModel.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace SearchAndCompare.Migrations
+{
+    public partial class SimplifySubjectFundingModel : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BursaryLowerSecond",
+                table: "subject-funding");
+
+            migrationBuilder.DropColumn(
+                name: "BursaryUpperSecond",
+                table: "subject-funding");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "BursaryLowerSecond",
+                table: "subject-funding",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "BursaryUpperSecond",
+                table: "subject-funding",
+                nullable: true);
+        }
+    }
+}

--- a/src/domain/Models/SubjectFunding.cs
+++ b/src/domain/Models/SubjectFunding.cs
@@ -12,9 +12,5 @@ namespace GovUk.Education.SearchAndCompare.Domain.Models
         public int? EarlyCareerPayments { get; set; }
 
         public int? BursaryFirst { get; set; }
-
-        public int? BursaryUpperSecond { get; set; }
-
-        public int? BursaryLowerSecond { get; set; }
     }
 }


### PR DESCRIPTION
https://trello.com/c/qGLbomUM/363-mock-up-the-process-for-financial-incentives-updates

There is no longer a distinction between grades for bursary funds, so we
remove the columns that had captured that distinction.