### PR TITLE
Change order of search results when searched by provider

### DIFF
--- a/src/api/Controllers/CoursesController.cs
+++ b/src/api/Controllers/CoursesController.cs
@@ -160,7 +160,8 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
                 {
                     courses = courses
                         .OrderBy(c => c.Provider.Name != filter.query) // false comes before true... (odd huh)
-                        .ThenByDescending(c => c.Provider.Name);
+                        .ThenByDescending(c => c.Provider.Name)
+                        .ThenBy(c => c.Name);
                     break;
                 }
                 case (SortByOption.Distance):
@@ -173,7 +174,8 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
                 {
                     courses = courses
                         .OrderBy(c => c.Provider.Name != filter.query) // false comes before true... (odd huh)
-                        .OrderBy(c => c.Provider.Name);
+                        .ThenBy(c => c.Provider.Name)
+                        .ThenBy(c => c.Name);
                     break;
                 }
             }


### PR DESCRIPTION
### Context

When users filter by providers ascending or descending, we should still order the subjects in alphabetical order.

### Changed proposed

A simple LINQ (?) query update.

### Guidance

I don't know how to test this, if someone could give a hand, happy to pair.