### PR TITLE
When there is a search query, put provider ahead of accredited matches

### DIFF
--- a/src/api/Controllers/CoursesController.cs
+++ b/src/api/Controllers/CoursesController.cs
@@ -158,7 +158,9 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
             {
                 case (SortByOption.ZtoA):
                 {
-                    courses = courses.OrderByDescending(c => c.Provider.Name);
+                    courses = courses
+                        .OrderBy(c => c.Provider.Name != filter.query) // false comes before true... (odd huh)
+                        .ThenByDescending(c => c.Provider.Name);
                     break;
                 }
                 case (SortByOption.Distance):
@@ -169,7 +171,9 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
                 default:
                 case (SortByOption.AtoZ):
                 {
-                    courses = courses.OrderBy(c => c.Provider.Name);
+                    courses = courses
+                        .OrderBy(c => c.Provider.Name != filter.query) // false comes before true... (odd huh)
+                        .OrderBy(c => c.Provider.Name);
                     break;
                 }
             }


### PR DESCRIPTION
https://trello.com/c/i2nx7BPC/401-sort-searching-by-training-provider-to-put-the-provider-first-followed-by-providers-they-accredit#