### PR TITLE
Compounding errors caused by dupes

### DIFF
--- a/src/api/DatabaseAccess/CourseDbContext.cs
+++ b/src/api/DatabaseAccess/CourseDbContext.cs
@@ -121,7 +121,7 @@ WHERE lower(""p1"".""Name"") = lower(@query) OR lower(""p2"".""Name"") = lower(@
 
             return ForListing(Courses.FromSql(@"
 SELECT ""course"".*, c1.""Distance""
-FROM course_distance(@lat,@lon,@rad) AS ""c1"" 
+FROM course_distance(@lat,@lon,@rad) AS ""c1""
 JOIN ""course"" on ""course"".""Id"" = ""c1"".""Id""
 LEFT OUTER JOIN ""provider"" AS ""p1"" ON ""course"".""ProviderId"" = ""p1"".""Id""
 LEFT OUTER JOIN ""provider"" AS ""p2"" ON ""course"".""AccreditingProviderId"" = ""p2"".""Id""
@@ -142,6 +142,8 @@ WHERE lower(""p1"".""Name"") = lower(@query) OR lower(""p2"".""Name"") = lower(@
             var existingCourse = await GetCourses(itemToSave.Provider.ProviderCode, itemToSave.ProgrammeCode)
             // Note: added course subjects as lack of it causes ef core tracking issues (ie added source and update with same data cause it to add course subject rather than update it)
             .Include(x => x.CourseSubjects)
+            .Include(x => x.DescriptionSections)
+            .Include(x => x.Campuses)
             .FirstOrDefaultAsync();
 
             if(existingCourse == null)

--- a/tests/Integration.Tests/Controllers/SaveSingleCourse_CoursesController.Tests.cs
+++ b/tests/Integration.Tests/Controllers/SaveSingleCourse_CoursesController.Tests.cs
@@ -301,7 +301,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
         }
 
         [Test]
-        public void ImportTwoCoursesTwice()
+        public void ImportSameCoursesTwice()
         {
             var course = GetCourses(1).First();
             var result1 = subject.SaveCourse(course.Provider.ProviderCode, course.ProgrammeCode, course).Result;;
@@ -314,6 +314,12 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
             var resultingCourses = context.GetCoursesWithProviderSubjectsRouteAndCampuses().ToList();
             var resultingProviders = context.Providers.ToList();
 
+            resultingCourses.Count().Should().Be(1);
+            var savedCourse = resultingCourses.First();
+            savedCourse.Campuses.Count().Should().Be(course.Campuses.Count());
+            savedCourse.DescriptionSections.Count().Should().Be(course.DescriptionSections.Count());
+            resultingCourses.SelectMany(x => x.DescriptionSections).Count().Should().Be(course.DescriptionSections.Count());
+
             // deduplicated
             resultingProviders.Count.Should().Be(1);
             context.Routes.Count().Should().Be(1);
@@ -321,7 +327,6 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
             context.Locations.Count().Should().Be(1);
 
             // non-deduplicated
-            resultingCourses.SelectMany(x => x.DescriptionSections).Distinct().Count().Should().Be(1);
 
             context.Campuses.Count().Should().Be(4); //probably wrong
             context.CourseSubjects.Count().Should().Be(1);


### PR DESCRIPTION
### Context
When updating a course in api then viewing it in ui, it bombs out due to dupes for course section descriptions.
As well as dupe listing of campuses.
 
### Changes proposed in this pull request
Fixed when updating a course its related collection items needs to loaded as well otherwise there is dupes in db.

