### PR TITLE
Fix course query serialisation

### DIFF
--- a/src/api/Controllers/CoursesController.cs
+++ b/src/api/Controllers/CoursesController.cs
@@ -290,9 +290,9 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
                 }
             }
 
-            var qualQts = filter.qualification.Any(x => x == QualificationOption.QtsOnly); 
-            var qualPgce = filter.qualification.Any(x => x == QualificationOption.PgdePgceWithQts); 
-            var qualOther = filter.qualification.Any(x => x == QualificationOption.Other); 
+            var qualQts = (filter.qualification & (byte) QualificationOption.QtsOnly) > 0; 
+            var qualPgce = (filter.qualification & (byte) QualificationOption.PgdePgceWithQts) > 0; 
+            var qualOther = (filter.qualification & (byte) QualificationOption.Other) > 0; 
             
             if(qualQts && qualPgce && qualOther)
             {
@@ -323,18 +323,18 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
             }
             else if(qualQts)
             {
-                courses.Where(x => x.IncludesPgce == IncludesPgce.No);
+                courses = courses.Where(x => x.IncludesPgce == IncludesPgce.No);
             }
             else if(qualPgce)
             {
-                courses.Where(x =>
+                courses = courses.Where(x =>
                     x.IncludesPgce == IncludesPgce.Yes ||
                     x.IncludesPgce == IncludesPgce.QtsWithOptionalPgce ||
                     x.IncludesPgce == IncludesPgce.QtsWithPgde);
             }
             else if(qualOther)
             {
-                courses.Where(x =>
+                courses = courses.Where(x =>
                     x.IncludesPgce == IncludesPgce.QtlsOnly ||
                     x.IncludesPgce == IncludesPgce.QtlsWithPgce ||
                     x.IncludesPgce == IncludesPgce.QtlsWithPgde);

--- a/src/domain/Filters/Enums/QualificationOption.cs
+++ b/src/domain/Filters/Enums/QualificationOption.cs
@@ -2,9 +2,10 @@ namespace GovUk.Education.SearchAndCompare.Domain.Filters.Enums
 {
     public enum QualificationOption
     {
-        QtsOnly = 1,
-        PgdePgceWithQts = 2,
+        QtsOnly = 1 << 0,
+        
+        PgdePgceWithQts = 1 << 1,
 
-        Other = 3
+        Other = 1 << 2
     }
 }

--- a/src/domain/Filters/QueryFilter.cs
+++ b/src/domain/Filters/QueryFilter.cs
@@ -11,11 +11,6 @@ namespace GovUk.Education.SearchAndCompare.Domain.Filters
 {
     public class QueryFilter
     {
-        public QueryFilter()
-        {
-            qualification = new List<QualificationOption>();
-        }
-
         public int? page { get; set; }
 
         public int? pageSize { get; set; }
@@ -38,7 +33,7 @@ namespace GovUk.Education.SearchAndCompare.Domain.Filters
 
         public bool parttime { get; set; }
 
-        public IList<QualificationOption> qualification { get; set;}
+        public byte qualification { get; set; }
 
         [IgnoreDataMemberAttribute]
         public List<int> SelectedSubjects {

--- a/src/domain/SearchAndCompareDomain.csproj
+++ b/src/domain/SearchAndCompareDomain.csproj
@@ -6,7 +6,7 @@
     <Authors>DfE Digital</Authors>
     <Title>Domain objects for SearchAndCompare project</Title>
     <Description>Domain objects for SearchAndCompare project</Description>
-    <VersionPrefix>0.7.0</VersionPrefix>
+    <VersionPrefix>0.8.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <RootNamespace>GovUk.Education.SearchAndCompare.Domain</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
### Context

Shipping

### Changes proposed in this pull request

The courses list is a get request so we need to serialise things into
a query string. However Lists are not supported at the moment.

To fix the fact that consequently, the qualification filter options got
dropped between API and UI, we use a bitmap instead.

### Guidance to review
