### PR TITLE
SaveCourse can now support multiple courses

### DIFF
--- a/src/api/Controllers/CoursesController.cs
+++ b/src/api/Controllers/CoursesController.cs
@@ -33,12 +33,17 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
             _logger = logger;
         }
 
-        [HttpPut("api/courses")]
+        [HttpPut("")]
         [ApiTokenAuth]
         [RequestSizeLimit(100_000_000_000)]
         public async Task<IActionResult> SaveCourses([FromBody]IList<Course> courses)
         {
             IActionResult result = BadRequest();
+
+            if (courses == null)
+            {
+                return result;
+            }
 
             var allCoursesValid = courses.All(x => x != null && x.IsValid(false));
 

--- a/src/domain/Client/HttpClientWrapper.cs
+++ b/src/domain/Client/HttpClientWrapper.cs
@@ -22,5 +22,10 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
         {
             return wrapped.PostAsync(queryUri, content);
         }
+
+        public Task<HttpResponseMessage> PutAsync(Uri queryUri, StringContent content)
+        {
+            return wrapped.PutAsync(queryUri, content);
+        }
     }
 }

--- a/src/domain/Client/IHttpClient.cs
+++ b/src/domain/Client/IHttpClient.cs
@@ -8,5 +8,6 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
     {
         Task<HttpResponseMessage> GetAsync(Uri queryUri);
         Task<HttpResponseMessage> PostAsync(Uri queryUri, StringContent content);
+        Task<HttpResponseMessage> PutAsync(Uri queryUri, StringContent content);
     }
 }

--- a/src/domain/Client/ISearchAndCompareApi.cs
+++ b/src/domain/Client/ISearchAndCompareApi.cs
@@ -11,7 +11,7 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
     {
         Course GetCourse(string providerCode, string courseCode);
 
-        Task<bool> SaveCourseAsync(Course courses);
+        Task<bool> UpdateCoursesAsync(IList<Course> courses);
 
         Task<bool> SaveCoursesAsync(IList<Course> courses);
 

--- a/src/domain/Client/SearchAndCompareApi.cs
+++ b/src/domain/Client/SearchAndCompareApi.cs
@@ -43,20 +43,18 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
             return GetObjects<Course>(queryUri);
         }
 
-        public async Task<bool> SaveCourseAsync(Course course)
+        public async Task<bool> UpdateCoursesAsync(IList<Course> courses)
         {
-            var result = course.IsValid(false);
+            var result = courses.All(course => course.IsValid(false));
 
             if (result)
             {
-                var programmeCode = course.ProgrammeCode;
-                var providerCode = course.Provider.ProviderCode;
-                var queryUri = GetUri($"/courses/{providerCode}/{programmeCode}");
+                var queryUri = GetUri($"/courses");
 
-                var courseJson = JsonConvert.SerializeObject(course, _serializerSettings);
+                var coursesJson = JsonConvert.SerializeObject(courses, _serializerSettings);
 
-                var courseStringContent = new StringContent(courseJson, Encoding.UTF8, "application/json" );
-                var response = await _httpClient.PostAsync(queryUri, courseStringContent);
+                var courseStringContent = new StringContent(coursesJson, Encoding.UTF8, "application/json" );
+                var response = await _httpClient.PutAsync(queryUri, courseStringContent);
 
                 result = response.IsSuccessStatusCode;
             }

--- a/src/domain/SearchAndCompareDomain.csproj
+++ b/src/domain/SearchAndCompareDomain.csproj
@@ -6,7 +6,7 @@
     <Authors>DfE Digital</Authors>
     <Title>Domain objects for SearchAndCompare project</Title>
     <Description>Domain objects for SearchAndCompare project</Description>
-    <VersionPrefix>0.8.0</VersionPrefix>
+    <VersionPrefix>0.9.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <RootNamespace>GovUk.Education.SearchAndCompare.Domain</RootNamespace>
   </PropertyGroup>

--- a/tests/Integration.Tests/Controllers/SaveSingleCourse_CoursesController.Tests.cs
+++ b/tests/Integration.Tests/Controllers/SaveSingleCourse_CoursesController.Tests.cs
@@ -56,17 +56,8 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
         [Test]
         public async Task ImportNullCourse()
         {
-            var result = await subject.SaveCourse(null, null, null);
+            var result = await subject.SaveCourses(null);
 
-            AssertBad(result);
-        }
-
-        [Test]
-        public async Task ImportNullCourse_ProgrammeCode()
-        {
-            var courses = GetCourses(1);
-            var course = courses.First();
-            var result = await subject.SaveCourse(course.Provider.ProviderCode, course.ProgrammeCode + 1, course);
             AssertBad(result);
         }
 
@@ -80,7 +71,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
             }
 
             var course = courses.First();
-            var result = await subject.SaveCourse(course.Provider.ProviderCode, course.ProgrammeCode, course);
+            var result = await subject.SaveCourses(new List<Course> { course });
 
             AssertBad(result);
         }
@@ -95,7 +86,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
             }
 
             var course = courses.First();
-            var result = await subject.SaveCourse(course.Provider.ProviderCode, course.ProgrammeCode, course);
+            var result = await subject.SaveCourses(new List<Course> { course });
 
             AssertOkay(result);
         }
@@ -110,7 +101,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
             }
 
             var course = courses.First();
-            var result = await subject.SaveCourse(course.Provider.ProviderCode, course.ProgrammeCode, course);
+            var result = await subject.SaveCourses(new List<Course> { course });
 
             AssertOkay(result);
         }
@@ -126,7 +117,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
             }
 
             var course = courses.First();
-            var result = await subject.SaveCourse(course.Provider.ProviderCode, course.ProgrammeCode, course);
+            var result = await subject.SaveCourses(new List<Course> { course });
 
             AssertBad(result);
         }
@@ -141,7 +132,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
             }
 
             var course = courses.First();
-            var result = await subject.SaveCourse(course.Provider.ProviderCode, course.ProgrammeCode, course);
+            var result = await subject.SaveCourses(new List<Course> { course });
 
             AssertBad(result);
         }
@@ -156,7 +147,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
             }
 
             var course = courses.First();
-            var result = await subject.SaveCourse("course.Provider.ProviderCode", course.ProgrammeCode, course);
+            var result = await subject.SaveCourses(new List<Course> {course});
 
             AssertBad(result);
         }
@@ -171,7 +162,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
             }
 
             var course = courses.First();
-            var result = await subject.SaveCourse(course.Provider.ProviderCode, course.ProgrammeCode, course);
+            var result = await subject.SaveCourses(new List<Course> { course });
 
             AssertBad(result);
         }
@@ -186,7 +177,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
             }
 
             var course = courses.First();
-            var result = await subject.SaveCourse(course.Provider.ProviderCode, course.ProgrammeCode, course);
+            var result = await subject.SaveCourses(new List<Course> { course });
 
             AssertOkay(result);
         }
@@ -202,7 +193,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
             }
 
             var course = courses.First();
-            var result = await subject.SaveCourse(course.Provider.ProviderCode, course.ProgrammeCode, course);
+            var result = await subject.SaveCourses(new List<Course> { course });
 
             AssertBad(result);
         }
@@ -217,7 +208,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
             }
 
             var course = courses.First();
-            var result = await subject.SaveCourse(course.Provider.ProviderCode, course.ProgrammeCode, course);
+            var result = await subject.SaveCourses(new List<Course> { course });
 
             AssertBad(result);
         }
@@ -235,7 +226,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
             }
 
             var course = courses.First();
-            var result = await subject.SaveCourse(course.Provider.ProviderCode, course.ProgrammeCode, course);
+            var result = await subject.SaveCourses(new List<Course> { course });
 
             AssertBad(result);
         }
@@ -250,7 +241,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
             }
 
             var course = courses.First();
-            var result = await subject.SaveCourse(course.Provider.ProviderCode, course.ProgrammeCode, course);
+            var result = await subject.SaveCourses(new List<Course> { course });
 
             AssertOkay(result);
         }
@@ -260,7 +251,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
         {
             var courses = GetCourses(1);
             var course = courses.First();
-            var result = await subject.SaveCourse(course.Provider.ProviderCode, course.ProgrammeCode, course);
+            var result = await subject.SaveCourses(new List<Course> { course });
 
             AssertOkay(result);
         }
@@ -270,12 +261,12 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
         {
             var courses = GetCourses(2);
             var course = courses.First();
-            var result = await subject.SaveCourse(course.Provider.ProviderCode, course.ProgrammeCode, course);
+            var result = await subject.SaveCourses(new List<Course> { course });
 
             AssertOkay(result);
 
             var course1 = courses[1];
-            var result1 = await subject.SaveCourse(course1.Provider.ProviderCode, course1.ProgrammeCode, course1);
+            var result1 = await subject.SaveCourses(new List<Course>{course1});
 
             AssertOkay(result1);
             var resultingCourses = context.GetCoursesWithProviderSubjectsRouteAndCampuses()
@@ -304,11 +295,11 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
         public void ImportSameCoursesTwice()
         {
             var course = GetCourses(1).First();
-            var result1 = subject.SaveCourse(course.Provider.ProviderCode, course.ProgrammeCode, course).Result;;
+            var result1 = subject.SaveCourses(new List<Course> { course }).Result;;
             AssertOkay(result1);
 
             var course2 = GetCourses(1).First();
-            var result2 = subject.SaveCourse(course2.Provider.ProviderCode, course2.ProgrammeCode, course2).Result;;
+            var result2 = subject.SaveCourses(new List<Course>{course2}).Result;;
             AssertOkay(result2);
 
             var resultingCourses = context.GetCoursesWithProviderSubjectsRouteAndCampuses().ToList();
@@ -338,7 +329,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
         {
             // initial import
             var course = GetCourses(1).First();
-            var result = await subject.SaveCourse(course.Provider.ProviderCode, course.ProgrammeCode, course);
+            var result = await subject.SaveCourses(new List<Course> { course });
 
             AssertOkay(result);
 
@@ -352,7 +343,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
 
             // second import, with equivalent addresses
             var course2 = GetCourses(1).First();
-            await subject.SaveCourse(course2.Provider.ProviderCode, course2.ProgrammeCode, course2);
+            await subject.SaveCourses(new List<Course>{course2});
 
             // coordinates previously set are still there
             context.Locations.Single().Latitude.Should().Be(51.0);
@@ -364,7 +355,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
         {
             // initial import
             var course = GetCourses(1).First();
-            var result = await subject.SaveCourse(course.Provider.ProviderCode, course.ProgrammeCode, course);
+            var result = await subject.SaveCourses(new List<Course> { course });
 
             AssertOkay(result);
 
@@ -377,7 +368,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
 
             // second import, with equivalent subject
             var course2 = GetCourses(1).First();
-            await subject.SaveCourse(course2.Provider.ProviderCode, course2.ProgrammeCode, course2);
+            await subject.SaveCourses(new List<Course>{course2});
 
             // subject area previously set is still there
             context.Subjects.Single().SubjectArea.Should().NotBeNull();

--- a/tests/Unit.Tests/Client/SearchAndCompareApi.Tests.cs
+++ b/tests/Unit.Tests/Client/SearchAndCompareApi.Tests.cs
@@ -68,14 +68,14 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Unit.Tests.Client
             var providerCode = course.Provider.ProviderCode;
             var programmeCode = course.ProgrammeCode;
 
-            mockHttp.Setup(x => x.PostAsync(It.Is<Uri>(y => y.AbsoluteUri == $"https://api.example.com/courses/{providerCode}/{programmeCode}"), It.IsAny<StringContent>())).ReturnsAsync(
+            mockHttp.Setup(x => x.PutAsync(It.Is<Uri>(y => y.AbsoluteUri == $"https://api.example.com/courses"), It.IsAny<StringContent>())).ReturnsAsync(
                 new HttpResponseMessage() {
                     StatusCode = HttpStatusCode.OK
                 }
             ).Verifiable();
 
             course.IsValid(false).Should().BeTrue();
-            var result = await sut.SaveCourseAsync(course);
+            var result = await sut.UpdateCoursesAsync(new List<Course> {course});
 
             result.Should().BeTrue();
             mockHttp.VerifyAll();


### PR DESCRIPTION
### Context

Publish courses when org enrichment is published 

### Changes proposed in this pull request

- change save course to a HTTP PUT to api/courses
- increase request size limit
- accept a list of courses rather than a single course

### Guidance to review
