### PR TITLE
Added exception throwing on the search and compare api client

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ First, bump the version number in SearchAndCompareDomain.csproj. The -beta suffi
 ```
 cd src/domain
 dotnet pack -o publish -c Release --version-suffix beta
-dotnet nuget push publish/DFE.SearchAndCompare.Domain.0.1.3-beta.nupkg -s https://www.nuget.org -k <NUGET_API_KEY>
+dotnet nuget push publish/DFE.SearchAndCompare.Domain.0.10.0-beta.nupkg -s https://www.nuget.org -k <NUGET_API_KEY>
 ```
 
 Make sure to change the package to reflect your version number, e.g. change "0.1.3". You'll also need to put in the API key for nuget.

--- a/src/domain/Client/HttpClientWrapper.cs
+++ b/src/domain/Client/HttpClientWrapper.cs
@@ -46,7 +46,15 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
 
         public Task<HttpResponseMessage> PutAsync(Uri queryUri, StringContent content)
         {
-            return wrapped.PutAsync(queryUri, content);
+            try
+            {
+                return wrapped.PutAsync(queryUri, content);
+            }
+            catch(Exception ex)
+            {
+                var msg = $"API PUT Failed uri {queryUri}";
+                throw new SearchAndCompareApiException(msg, ex);
+            }
         }
     }
 }

--- a/src/domain/Client/HttpClientWrapper.cs
+++ b/src/domain/Client/HttpClientWrapper.cs
@@ -10,17 +10,38 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
 
         public HttpClientWrapper(HttpClient wrapped)
         {
+            if(wrapped == null)
+            {
+                throw new SearchAndCompareApiException($"Failed to instantiate due to HttpClient = null");
+            }
+
             this.wrapped = wrapped;
         }
 
         public Task<HttpResponseMessage> GetAsync(Uri queryUri)
         {
-            return wrapped.GetAsync(queryUri);
+            try
+            {
+                return wrapped.GetAsync(queryUri);
+            }
+            catch(Exception ex)
+            {
+                var msg = $"API GET Failed uri {queryUri}";
+                throw new SearchAndCompareApiException(msg, ex);
+            }
         }
 
         public Task<HttpResponseMessage> PostAsync(Uri queryUri, StringContent content)
         {
-            return wrapped.PostAsync(queryUri, content);
+            try
+            {
+                return wrapped.PostAsync(queryUri, content);
+            }
+            catch(Exception ex)
+            {
+                var msg = $"API POST Failed uri {queryUri}";
+                throw new SearchAndCompareApiException(msg, ex);
+            }
         }
 
         public Task<HttpResponseMessage> PutAsync(Uri queryUri, StringContent content)

--- a/src/domain/Client/SearchAndCompareApi.cs
+++ b/src/domain/Client/SearchAndCompareApi.cs
@@ -31,6 +31,11 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
 
         public SearchAndCompareApi(IHttpClient httpClient, string apiUri)
         {
+            if(string.IsNullOrWhiteSpace(apiUri))
+            {
+                throw new SearchAndCompareApiException($"Failed to instantiate due apiUri is null or white space");
+            }
+
             _httpClient = httpClient;
             _apiUri = apiUri;
             if (_apiUri.EndsWith('/')) { _apiUri = _apiUri.Remove(_apiUri.Length - 1); }

--- a/src/domain/Client/SearchAndCompareApiException.cs
+++ b/src/domain/Client/SearchAndCompareApiException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace GovUk.Education.SearchAndCompare.Domain.Client
+{
+    public class SearchAndCompareApiException : Exception
+    {
+        public SearchAndCompareApiException(string message) : base(message)
+        {
+        }
+
+        public SearchAndCompareApiException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/domain/SearchAndCompareDomain.csproj
+++ b/src/domain/SearchAndCompareDomain.csproj
@@ -6,7 +6,7 @@
     <Authors>DfE Digital</Authors>
     <Title>Domain objects for SearchAndCompare project</Title>
     <Description>Domain objects for SearchAndCompare project</Description>
-    <VersionPrefix>0.9.0</VersionPrefix>
+    <VersionPrefix>0.10.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <RootNamespace>GovUk.Education.SearchAndCompare.Domain</RootNamespace>
   </PropertyGroup>

--- a/tests/Unit.Tests/Client/HttpClientWrapperTests.cs
+++ b/tests/Unit.Tests/Client/HttpClientWrapperTests.cs
@@ -87,5 +87,25 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Unit.Tests.Client
             var msg = $"API GET Failed uri {uri}";
             act.Should().Throw<SearchAndCompareApiException>().WithMessage(msg);
         }
+
+        [Test]
+        public async Task PutAsync_SearchAndCompareApiException()
+        {
+            var ub = new UriBuilder("test");
+            var uri = ub.Uri;
+            var sc = new StringContent("tested");
+
+            mockMessageHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() => throw new Exception());
+
+            // Func<Task<HttpResponseMessage>> func = async () => await sut.PostAsync(uri, sc);
+            Action act = () => sut.PutAsync(uri, sc);
+
+
+            var msg = $"API Put Failed uri {uri}";
+            act.Should().Throw<SearchAndCompareApiException>().WithMessage(msg);
+        }
     }
 }

--- a/tests/Unit.Tests/Client/HttpClientWrapperTests.cs
+++ b/tests/Unit.Tests/Client/HttpClientWrapperTests.cs
@@ -8,6 +8,7 @@ using GovUk.Education.SearchAndCompare.Domain.Client;
 using Moq;
 using Moq.Protected;
 using NUnit.Framework;
+using FluentAssertions;
 
 namespace GovUk.Education.SearchAndCompare.Api.Tests.Unit.Tests.Client
 {
@@ -21,6 +22,14 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Unit.Tests.Client
         {
             mockMessageHandler = new Mock<HttpMessageHandler>();
             sut = new HttpClientWrapper(new HttpClient(mockMessageHandler.Object));
+        }
+
+        [Test]
+        public void Constructor_Exception()
+        {
+            Action act = () => new HttpClientWrapper(null);
+            var msg = $"Failed to instantiate due to HttpClient = null";
+            act.Should().Throw<SearchAndCompareApiException>().WithMessage(msg);
         }
 
         [Test]
@@ -39,6 +48,44 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Unit.Tests.Client
             mockMessageHandler.VerifyAll();
 
             Assert.Pass("Verified underlaying http client was called");
+        }
+
+        [Test]
+        public async Task SendAsync_SearchAndCompareApiException()
+        {
+            var ub = new UriBuilder("test");
+            var uri = ub.Uri;
+            var sc = new StringContent("tested");
+
+            mockMessageHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() => throw new Exception());
+
+            // Func<Task<HttpResponseMessage>> func = async () => await sut.PostAsync(uri, sc);
+            Action act = () => sut.PostAsync(uri, sc);
+
+            var msg = $"API POST Failed uri {uri}";
+            act.Should().Throw<SearchAndCompareApiException>().WithMessage(msg);
+        }
+
+        [Test]
+        public async Task GetAsync_SearchAndCompareApiException()
+        {
+            var ub = new UriBuilder("test");
+            var uri = ub.Uri;
+
+            mockMessageHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() => throw new Exception());
+
+            // Func<Task<HttpResponseMessage>> func = async () => await sut.PostAsync(uri, sc);
+            Action act = () => sut.GetAsync(uri);
+
+
+            var msg = $"API GET Failed uri {uri}";
+            act.Should().Throw<SearchAndCompareApiException>().WithMessage(msg);
         }
     }
 }

--- a/tests/Unit.Tests/Client/SearchAndCompareApi.Tests.cs
+++ b/tests/Unit.Tests/Client/SearchAndCompareApi.Tests.cs
@@ -27,6 +27,17 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Unit.Tests.Client
         }
 
         [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        public void Constructor_Exception(string value)
+        {
+            Action act = () => new SearchAndCompareApi(mockHttp.Object, value);
+            var msg = $"Failed to instantiate due apiUri is null or white space";
+            act.Should().Throw<SearchAndCompareApiException>().WithMessage(msg);
+        }
+
+        [Test]
         public void GetCourse_CallsCorrectUrl()
         {
             mockHttp.Setup(x => x.GetAsync(It.Is<Uri>(y => y.AbsoluteUri == "https://api.example.com/courses/XYZ/1AB"))).ReturnsAsync(


### PR DESCRIPTION
### Context
Throw dedicated exception.

As the `SearchAndCompareApi` class is shared it needs to capture and throw its own exception.

Throwing it's own exception helps to exposes and highlight to the caller that is trying to connect to `SearchAndCompareApi`

For `Developers` to realise without a doubt that the `SearchAndCompareApi` failed due to connectivity or config.

For `Application Insights` to able to show the dependencies failed to connect to `SearchAndCompareApi`

For dependencies such as:

`SearchAndCompareUI` to have a better way of handling the fact that `SearchAndCompareApi` is down/out of action.

`ManageCourseApi` to have a better way of handling the fact that `SearchAndCompareApi` is down/out of action.

### Changes proposed in this pull request
Throw dedicated exception
