### PR TITLE
Provider search prefers exact matches

### DIFF
--- a/src/api/DatabaseAccess/CourseDbContext.cs
+++ b/src/api/DatabaseAccess/CourseDbContext.cs
@@ -227,7 +227,7 @@ SELECT * FROM (
     JOIN ""course"" ON ""course"".""ProviderId"" = ""provider"".""Id""  OR ""course"".""AccreditingProviderId"" = ""provider"".""Id""
     WHERE (to_tsvector('english', ""provider"".""Name"") @@ to_tsquery('english', quote_literal(@query) || ':*')) IS TRUE
     GROUP BY ""provider"".""Id"") AS sub
-ORDER BY ""cnt"" DESC
+ORDER BY lower(""Name"") <> lower(@query) ASC, ""cnt"" DESC
 LIMIT @limit",
             new NpgsqlParameter("@query", query),
             new NpgsqlParameter("@limit", 5))

--- a/tests/Integration.Tests/DatabaseAccess/CourseDbContextIntegrationTests.cs
+++ b/tests/Integration.Tests/DatabaseAccess/CourseDbContextIntegrationTests.cs
@@ -134,6 +134,36 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.DatabaseA
         }
 
         [Test]
+        public void ProviderSuggest_ExactMatchesPreferred()
+        {
+            Assert.AreEqual(0, context.Courses.Count());            
+
+            var course1 = GetSimpleCourse();
+            var course2 = GetSimpleCourse();
+            var course3 = GetSimpleCourse();
+
+            var provider1 = new Provider { Name = "Teach"};
+            var provider2 = new Provider { Name = "Teach2"};
+
+            course1.Provider = provider1;
+            course2.Provider = provider2;
+            course3.Provider = provider2;
+
+            entitiesToCleanUp.Add(context.Courses.Add(course1));
+            entitiesToCleanUp.Add(context.Courses.Add(course2));
+            entitiesToCleanUp.Add(context.Courses.Add(course3));
+
+            context.SaveChanges();
+
+
+            using (var context2 = GetContext())
+            {
+                Assert.AreEqual("Teach2", context.SuggestProviders("tea").First().Name, "should be sorted by course count by default");
+                Assert.AreEqual("Teach", context.SuggestProviders("teach").First().Name, "should prefer exact matches");
+            }
+        }
+
+        [Test]
         public void RetrieveByIdCaseInsenstive()
         {
             Assert.AreEqual(0, context.Courses.Count());
@@ -202,7 +232,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.DatabaseA
                 Salary = new Salary(),
                 DescriptionSections = new HashSet<CourseDescriptionSection>
                 {
-                    new CourseDescriptionSection { Id = 1, Name = "Title", Text = "Content" }
+                    new CourseDescriptionSection { Name = "Title", Text = "Content" }
                 }
             };
         }


### PR DESCRIPTION
### Context

Zendesk: We had an issue that a provider with a smaller number of courses
was drowned out by providers with more courses. Since they had a short name,
no text search could be formed to return this provider in the 5 suggestions.  

### Changes proposed in this pull request

This changes selection logic to say that if an exact match is available,
show this as the first result.

### Guidance to review

see tests