### PR TITLE
add distance address

### DIFF
--- a/src/api/Migrations/20181006050158_AddDistanceAddress.Designer.cs
+++ b/src/api/Migrations/20181006050158_AddDistanceAddress.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using GovUk.Education.SearchAndCompare.Api.DatabaseAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace SearchAndCompare.Migrations
 {
     [DbContext(typeof(CourseDbContext))]
-    partial class CourseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20181006050158_AddDistanceAddress")]
+    partial class AddDistanceAddress
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/api/Migrations/20181006050158_AddDistanceAddress.cs
+++ b/src/api/Migrations/20181006050158_AddDistanceAddress.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace SearchAndCompare.Migrations
+{
+    public partial class AddDistanceAddress : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"DROP FUNCTION course_distance(double precision,
+                                                                 double precision,
+                                                                 double precision);");
+
+            migrationBuilder.Sql(@"CREATE OR REPLACE FUNCTION course_distance( lat DOUBLE PRECISION, 
+                                                            lon DOUBLE PRECISION, 
+                                                            rad DOUBLE PRECISION) 
+                                            RETURNS TABLE (""Id"" integer,
+                                                           ""Distance"" double precision,
+                                                           ""DistanceAddress"" text) AS $$
+                    WITH all_locs AS (
+                        SELECT course.""Id"", earth_distance(ll_to_earth(lat, lon), ll_to_earth(loc.""Latitude"",loc.""Longitude"")) AS ""Distance"", loc.""Address""
+                        FROM ""course""
+                        JOIN location loc ON course.""ProviderLocationId"" = loc.""Id""
+                        WHERE ""earth_box""(ll_to_earth(lat, lon), rad) @> ll_to_earth(loc.""Latitude"",loc.""Longitude"")
+                            AND earth_distance(ll_to_earth(lat, lon), ll_to_earth(loc.""Latitude"",loc.""Longitude"")) <= rad
+                        UNION ALL
+                        SELECT course.""Id"", earth_distance(ll_to_earth(lat, lon), ll_to_earth(loc.""Latitude"",loc.""Longitude"")) AS ""Distance"", loc.""Address"" 
+                        FROM ""course""
+                        JOIN campus on campus.""CourseId"" = course.""Id""
+                        JOIN location loc ON campus.""LocationId"" = loc.""Id""			
+                        WHERE ""earth_box""(ll_to_earth(lat, lon), rad) @> ll_to_earth(loc.""Latitude"",loc.""Longitude"")
+                            AND earth_distance(ll_to_earth(lat, lon), ll_to_earth(loc.""Latitude"",loc.""Longitude"")) <= rad
+                    ), all_locs_rows AS (
+                        SELECT *, ROW_NUMBER() OVER(PARTITION BY ""Id"" ORDER BY ""Distance"" ASC) as ordinal
+                        FROM all_locs
+                    )
+                    SELECT ""Id"", ""Distance"", ""Address"" AS ""DistanceAddress""
+                    FROM all_locs_rows WHERE ordinal = 1      
+                $$ LANGUAGE SQL;");            
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"DROP FUNCTION course_distance(double precision,
+                                                                 double precision,
+                                                                 double precision);");
+
+            migrationBuilder.Sql(@"CREATE OR REPLACE FUNCTION course_distance( lat DOUBLE PRECISION, 
+                                                            lon DOUBLE PRECISION, 
+                                                            rad DOUBLE PRECISION) 
+                                            RETURNS TABLE (""Id"" integer,
+                                                           ""Distance"" double precision) AS $$
+                    SELECT ""Id"", MIN(""Distance"") AS ""Distance""
+                    FROM (
+                        SELECT course.""Id"", earth_distance(ll_to_earth(lat, lon), ll_to_earth(loc.""Latitude"",loc.""Longitude"")) AS ""Distance""
+                        FROM ""course""
+                        JOIN location loc ON course.""ProviderLocationId"" = loc.""Id""
+                        WHERE ""earth_box""(ll_to_earth(lat, lon), rad) @> ll_to_earth(loc.""Latitude"",loc.""Longitude"")
+                            AND earth_distance(ll_to_earth(lat, lon), ll_to_earth(loc.""Latitude"",loc.""Longitude"")) <= rad
+                        UNION ALL
+                        SELECT course.""Id"", earth_distance(ll_to_earth(lat, lon), ll_to_earth(loc.""Latitude"",loc.""Longitude"")) AS ""Distance"" 
+                        FROM ""course""
+                        JOIN campus on campus.""CourseId"" = course.""Id""
+                        JOIN location loc ON campus.""LocationId"" = loc.""Id""			
+                        WHERE ""earth_box""(ll_to_earth(lat, lon), rad) @> ll_to_earth(loc.""Latitude"",loc.""Longitude"")
+                            AND earth_distance(ll_to_earth(lat, lon), ll_to_earth(loc.""Latitude"",loc.""Longitude"")) <= rad ) x
+                    GROUP BY ""Id""       
+                $$ LANGUAGE SQL;");            
+        }
+    }
+}

--- a/src/domain/Models/Course.cs
+++ b/src/domain/Models/Course.cs
@@ -52,6 +52,8 @@ namespace GovUk.Education.SearchAndCompare.Domain.Models
 
         public double? Distance { get; set; }
 
+        public string DistanceAddress { get; set; }
+
         public int? ContactDetailsId { get; set; }
 
         public Contact ContactDetails { get; set; }

--- a/src/domain/SearchAndCompareDomain.csproj
+++ b/src/domain/SearchAndCompareDomain.csproj
@@ -6,7 +6,7 @@
     <Authors>DfE Digital</Authors>
     <Title>Domain objects for SearchAndCompare project</Title>
     <Description>Domain objects for SearchAndCompare project</Description>
-    <VersionPrefix>0.10.1</VersionPrefix>
+    <VersionPrefix>0.10.2</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <RootNamespace>GovUk.Education.SearchAndCompare.Domain</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
### Context

When a user searches by location, we match on the closest location but show the default provider address, causing confusion. So we want to show the address we matched on in the UI

### Changes proposed in this pull request

Introduces a new field `DistanceAddress` to course and update the location queries to set it to the matching address at query-time.

Uses the same trick as for `Distance` to ensure no corresponding column is generated.

### Guidance to review

See test - note that DbContext caches results so fields that are populated ad-hoc such as `Distance` and `DistanceAddress` will always be the same even if you change search parameters. For that reason, the test needs to get a fresh context for each query.