### PR TITLE
Changed query

### DIFF
--- a/src/api/DatabaseAccess/CourseDbContext.cs
+++ b/src/api/DatabaseAccess/CourseDbContext.cs
@@ -234,6 +234,7 @@ SELECT * FROM (
     FROM ""provider""
     JOIN ""course"" ON ""course"".""ProviderId"" = ""provider"".""Id""  OR ""course"".""AccreditingProviderId"" = ""provider"".""Id""
     WHERE (to_tsvector('english', ""provider"".""Name"") @@ to_tsquery('english', quote_literal(@query) || ':*')) IS TRUE
+    OR (to_tsvector('english', ""provider"".""ProviderCode"") @@ to_tsquery('english', quote_literal(@query) || ':*')) IS TRUE
     GROUP BY ""provider"".""Id"") AS sub
 ORDER BY lower(""Name"") <> lower(@query) ASC, ""cnt"" DESC
 LIMIT @limit",

--- a/tests/Integration.Tests/DatabaseAccess/CourseDbContextIntegrationTests.cs
+++ b/tests/Integration.Tests/DatabaseAccess/CourseDbContextIntegrationTests.cs
@@ -167,6 +167,29 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.DatabaseA
         }
 
         [Test]
+        [TestCase("xyz", 1)]
+        [TestCase("wxy", 1)]
+        [TestCase("xxx", 0)]
+        [TestCase("xy", 1)]
+        [TestCase("wx", 1)]
+        [TestCase("x", 1)]
+        [TestCase("w", 1)]
+        [TestCase("y", 0)]
+        public void ProviderSuggest_ProviderCode(string query, int expectedCount)
+        {
+            Assert.AreEqual(0, context.Courses.Count());
+
+            var entity = context.Courses.Add(GetSimpleCourse());
+            context.SaveChanges();
+            entitiesToCleanUp.Add(entity);
+
+            using (var context2 = GetContext())
+            {
+                Assert.AreEqual(expectedCount, context2.SuggestProviders(query).Count(), "complete");
+            }
+        }
+
+        [Test]
         public void ProviderSuggest_ExactMatchesPreferred()
         {
             Assert.AreEqual(0, context.Courses.Count());            


### PR DESCRIPTION
### Context
There is a requirement to search by Ucas provider code on the Search By Location page.
https://trello.com/c/RHCRbSz8/431-search-by-provider-code-on-location-search-page

### Changes proposed in this pull request
There is now an extra step in the query in the SuggestProviders() method. It now searches the provider code field as well as the provider name field.
