### PR TITLE
HttpWrapper now handles internal errors

### DIFF
--- a/src/domain/Client/HttpClientWrapper.cs
+++ b/src/domain/Client/HttpClientWrapper.cs
@@ -22,7 +22,9 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
         {
             try
             {
-                return await wrapped.GetAsync(queryUri);
+                var result = await wrapped.GetAsync(queryUri);
+                result.EnsureSuccessStatusCode();//handle internal error
+                return result;
             }
             catch(Exception ex)
             {
@@ -35,7 +37,9 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
         {
             try
             {
-                return await wrapped.PostAsync(queryUri, content);
+                var result = await wrapped.PostAsync(queryUri, content);
+                result.EnsureSuccessStatusCode();//handle internal error
+                return result;
             }
             catch(Exception ex)
             {
@@ -48,7 +52,9 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
         {
             try
             {
-                return await wrapped.PutAsync(queryUri, content);
+                var result = await wrapped.PutAsync(queryUri, content);
+                result.EnsureSuccessStatusCode();//handle internal error
+                return result;
             }
             catch(Exception ex)
             {

--- a/src/domain/Client/HttpClientWrapper.cs
+++ b/src/domain/Client/HttpClientWrapper.cs
@@ -23,7 +23,7 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
             try
             {
                 var result = await wrapped.GetAsync(queryUri);
-                result.EnsureSuccessStatusCode();//handle internal error
+                result.EnsureSuccessStatusCode();
                 return result;
             }
             catch(Exception ex)
@@ -38,7 +38,7 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
             try
             {
                 var result = await wrapped.PostAsync(queryUri, content);
-                result.EnsureSuccessStatusCode();//handle internal error
+                result.EnsureSuccessStatusCode();
                 return result;
             }
             catch(Exception ex)
@@ -53,7 +53,7 @@ namespace GovUk.Education.SearchAndCompare.Domain.Client
             try
             {
                 var result = await wrapped.PutAsync(queryUri, content);
-                result.EnsureSuccessStatusCode();//handle internal error
+                result.EnsureSuccessStatusCode();
                 return result;
             }
             catch(Exception ex)


### PR DESCRIPTION
### Context
The HttpWrapper class was created to handle exceptions when making requests to the Api. Any exceptions would result in a "Service Down" page being shown in the ui.
However when the api returned an internal error such as when the database is down then this was not handled and a non-styled error page was shown in the ui. 
