### PR TITLE
Don't throw when a course isn't found, 404 instead

### DIFF
--- a/src/api/Controllers/CoursesController.cs
+++ b/src/api/Controllers/CoursesController.cs
@@ -205,6 +205,11 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
         {
             var course = await _context.GetCourseWithProviderSubjectsRouteCampusesAndDescriptions(providerCode, courseCode);
 
+            if (course == null)
+            {
+                return NotFound();
+            }
+
             return Ok(course);
         }
 

--- a/src/api/DatabaseAccess/CourseDbContext.cs
+++ b/src/api/DatabaseAccess/CourseDbContext.cs
@@ -169,7 +169,7 @@ WHERE lower(""p1"".""Name"") = lower(@query) OR lower(""p2"".""Name"") = lower(@
         public async Task<Course> GetCourseWithProviderSubjectsRouteCampusesAndDescriptions(string providerCode, string courseCode)
         {
             return await GetCoursesWithProviderSubjectsRouteAndCampuses(providerCode, courseCode)
-                .Include(x => x.DescriptionSections).FirstAsync();
+                .Include(x => x.DescriptionSections).FirstOrDefaultAsync();
         }
 
         private IQueryable<Course> GetCourses(string providerCode, string courseCode)


### PR DESCRIPTION
### Context

Errors in prod when crawled because of bad links, causing noise in exception logs

### Changes proposed in this pull request
Cope with missing data

For some reason errors in prod are already 404s, so visible behaviour isn't actually different.