### PR TITLE
Switch to 401 for api-key auth failures

### DIFF
--- a/src/api/Middleware/BearerTokenApiKeyHandler.cs
+++ b/src/api/Middleware/BearerTokenApiKeyHandler.cs
@@ -54,7 +54,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Middleware
             }
 
             _logger.LogError(authException, "Failed api-key challenge");
-            Context.Response.StatusCode = 404; // todo: return 500 if there's an exception, 401 otherwise
+            Context.Response.StatusCode = 401;
             return Task.CompletedTask;
 
         }


### PR DESCRIPTION
To try and figure out if the 404s seen on prod are anything to do with this bit of code.
