### PR TITLE
Don't terrify the admin with a scary log message

### DIFF
--- a/src/api/Controllers/CoursesController.cs
+++ b/src/api/Controllers/CoursesController.cs
@@ -112,7 +112,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
                         _context.Routes.RemoveRange(_context.Routes);
 
                         _context.SaveChanges();
-                        _logger.LogInformation($"Existing Courses Removed");
+                        _logger.LogInformation($"Existing Courses Removed (don't worry it's in a transaction, they'll be back soon)");
 
                         MakeProvidersDistinctReferences(ref courses);
                         MakeRoutesDistinctReferences(ref courses);


### PR DESCRIPTION
The removal happens within a transaction and is followed by a re-add,
but there's a two minute pause between that and the next message.
To avoid giving someone heart-failure add some more context to the
message.
