### PR TITLE
mapped sen courses flag plus test

### DIFF
--- a/src/api/DatabaseAccess/CourseDbContext.cs
+++ b/src/api/DatabaseAccess/CourseDbContext.cs
@@ -291,6 +291,7 @@ LIMIT @limit",
             existingCourse.Duration = itemToSave.Duration;
             existingCourse.Mod = itemToSave.Mod;
             existingCourse.HasVacancies = itemToSave.HasVacancies;
+            existingCourse.IsSen = itemToSave.IsSen;
             // itemToSave.Id = existingCourse.Id;
         }
     }

--- a/tests/Integration.Tests/Controllers/SaveSingleCourse_CoursesController.Tests.cs
+++ b/tests/Integration.Tests/Controllers/SaveSingleCourse_CoursesController.Tests.cs
@@ -374,7 +374,28 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
             context.Subjects.Single().SubjectArea.Should().NotBeNull();
             context.Subjects.Single().SubjectArea.Name.Should().Be("Primary");
         }
+        [Test]
+        public async Task SenCoursesArePreservedAcrossImports()
+        {
+            // initial import
+            var course = GetCourses(1).First();
+            course.IsSen = true;
+            var result = await subject.SaveCourses(new List<Course> { course });
 
+            AssertOkay(result);
+
+            var savedCourse = context.GetCoursesWithProviderSubjectsRouteAndCampuses().Single();
+            savedCourse.IsSen.Should().BeTrue();
+            // next import
+            var course2 = GetCourses(1).First();
+            course2.IsSen = false;
+            var result2 = await subject.SaveCourses(new List<Course> { course2 });
+
+            AssertOkay(result2);
+
+            savedCourse = context.GetCoursesWithProviderSubjectsRouteAndCampuses().Single();
+            savedCourse.IsSen.Should().BeFalse();
+        }
         internal void AssertBad(IActionResult result)
         {
             AssertStatusCode(result, 400);


### PR DESCRIPTION
### Context
This is part of the story to search by SEN courses. Here is the card:
https://trello.com/c/dehAp9dq/574-search-by-send-courses 
### Changes proposed in this pull request
The flag wasn't being set on import and this PR fixes the bug
