### PR TITLE
Geocoding webjob

### DIFF
--- a/src/geocoder/LocationRequester.cs
+++ b/src/geocoder/LocationRequester.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 using GovUk.Education.SearchAndCompare.Api.DatabaseAccess;
 using GovUk.Education.SearchAndCompare.Domain.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
 using Serilog;
 using Serilog.Core;
 
@@ -26,40 +28,57 @@ namespace GovUk.Education.SearchAndCompare.Geocoder
             this._context = context;
         }
 
-        public async Task RequestLocations()
+
+        private List<Location> GetLocationsToGeocode()
         {
             var locations = _context.Locations
-                .Where(x => x.Latitude == null) // choose un-geocoded locations...
-                .OrderBy(x => x.LastGeocodedUtc) // ... preferring those that we haven't attempted recently
+                .Where(x => (x.Latitude == null || x.Longitude == null) || x.LastGeocodedUtc == DateTime.MinValue)
+                .OrderBy(x => x.LastGeocodedUtc)
                 .Take(_config.BatchSize)
                 .ToList();
 
-            var locationQueries = new Dictionary<int, Task<Coordinates>>();
+            return locations;
+        }
+
+        public async Task RequestLocations()
+        {
+            var locations = GetLocationsToGeocode();
+
             var geocoder = new TECH_DEBT__TemporarilyCopied__Geocoder(_config.ApiKey, _httpClient);
             var utcNow = DateTime.UtcNow;
 
-            foreach (var location in locations)
-            {
-                locationQueries.Add(
-                    location.Id,
-                    geocoder.ResolvePostCodeAsync(location.GeoAddress)
-                );
-            }
+            _logger.Information($"Geocode proccessing a total of : {locations.Count()}");
 
+            var failures = new Dictionary<string, string>();
             foreach (var location in locations)
             {
-                location.LastGeocodedUtc = utcNow;
-                var coordinates = await locationQueries[location.Id];
+
+                var coordinates = await geocoder.ResolvePostCodeAsync(location.GeoAddress);
                 if (coordinates != null)
                 {
                     location.FormattedAddress = coordinates.FormattedLocation;
                     location.Longitude = coordinates.Longitude;
                     location.Latitude = coordinates.Latitude;
+                    location.LastGeocodedUtc = utcNow;
                 }
                 else
                 {
-                    _logger.Information($"Unable to resolve address: {location.Id}, {location.GeoAddress}");
+                    failures.Add(location.Id.ToString(), location.GeoAddress);
                 }
+            }
+
+            if(failures.Any())
+            {
+
+                foreach(var failure in failures)
+                {
+                    _logger.Warning($"Geocode unable to resolve: {failure.Key}, {failure.Value}");
+                }
+
+                var msg = $"Geocode failures a total of : {failures.Count()}.{locations.Count()}";
+                _logger.Warning(msg);
+
+                new TelemetryClient().TrackTrace($"Geocode failures a total of : {failures.Count()}.{locations.Count()}", SeverityLevel.Error, failures);
             }
 
             _context.SaveChanges();

--- a/src/geocoder/Program.cs
+++ b/src/geocoder/Program.cs
@@ -10,16 +10,17 @@ using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Serilog;
+using System.Threading.Tasks;
 
 namespace GovUk.Education.SearchAndCompare.Geocoder
 {
     class Program
     {
-        static void Main(string[] args)
+        public static int Main(string[] args)
         {
             var configuration = GetConfiguration();
             var requesterConfig = LocationRequesterConfiguration.FromConfiguration(configuration);
-            
+
             var logger = new LoggerConfiguration()
                 .ReadFrom.Configuration(configuration)
                 .WriteTo
@@ -33,14 +34,16 @@ namespace GovUk.Education.SearchAndCompare.Geocoder
             var context = new CourseDbContext(options);
 
             logger.Information("Geocoder started.");
-            
+
             // Wait() because async Mains are not supported
             var locationRequester = new LocationRequester(requesterConfig, logger, new WrappedHttpClient(), context);
-            locationRequester.RequestLocations().Wait();
+            var exitcode = locationRequester.RequestLocations().Result;
 
             logger.Information("Geocoder finished.");
+
+            return exitcode;
         }
-        
+
         private static IConfiguration GetConfiguration()
         {
             return new ConfigurationBuilder()

--- a/tests/Integration.Tests/Geocoder/LocationRequester.Tests.cs
+++ b/tests/Integration.Tests/Geocoder/LocationRequester.Tests.cs
@@ -15,6 +15,7 @@ using MockQueryable.Moq;
 using Moq;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using FluentAssertions;
 
 namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Geocoder
 {
@@ -37,6 +38,81 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Geocoder
             context.Locations.RemoveRange(context.Locations);
             context.SaveChanges();
         }
+
+
+        [Test]
+        public void CompleteTest()
+        {
+            var now = DateTime.Now;
+            var testLocations = new List<Location>();
+            var geocodedLocations = Enumerable.Range(1, 10).ToList().Select(x => new Location {GeoAddress = x.ToString(), Address = x.ToString(), Latitude = x, Longitude = x, LastGeocodedUtc = now.AddDays(-x)});
+            var tobeGeocoded = Enumerable.Range(1, 10).ToList().Select(x => {
+                var location = new Location() {GeoAddress= "Needs_to_be_gecoded_" + x, Address = x.ToString()};
+
+                var mod = x % 4;
+                switch(mod)
+                {
+                    case 0:
+                        location.Latitude = x;
+                        location.LastGeocodedUtc = now;
+                        break;
+                    case 1:
+                        location.Longitude = x;
+                        location.LastGeocodedUtc = now;
+                        break;
+                    case 2:
+                        location.LastGeocodedUtc = now;
+                        break;
+                    case 3:
+                        location.Latitude = x;
+                        location.Longitude = x;
+                        location.LastGeocodedUtc = DateTime.MinValue;
+                        break;
+                }
+                return location;
+                });
+
+            var httpClientSetup = tobeGeocoded.ToDictionary(x => "https://maps.googleapis.com/maps/api/geocode/json?key=apiKey&region=uk&address=" + x.GeoAddress, x => ResponseWithBody(new {
+                    status = "OK",
+                    results = new object[] {
+                        new {
+                            address_components = new object[] {
+                                new {
+                                    types = new string[] {
+                                        "country"
+                                    },
+                                    short_name = "GB"
+                                }
+                            },
+                            formatted_address = x.GeoAddress.Replace('_', ' '),
+                            geometry = new {
+                                location = new {
+                                    lat = double.Parse(x.Address) * 2,
+                                    lng = double.Parse(x.Address) * 2
+                                }
+                            }
+                        }
+                    }}));
+
+            foreach (var item in httpClientSetup)
+            {
+                httpClient.Setup(x => x.GetAsync(item.Key))
+                    .ReturnsAsync(item.Value)
+                    .Verifiable();
+            }
+
+            context.Locations.AddRange(geocodedLocations);
+            context.Locations.AddRange(tobeGeocoded);
+            context.SaveChanges();
+
+            system.RequestLocations().Wait();
+
+            httpClient.VerifyAll();
+            var hasGeocoded = context.Locations.Where(x => x.GeoAddress.StartsWith("Needs_to_be_gecoded_")).ToList();
+            hasGeocoded.Should().HaveCount(tobeGeocoded.Count());
+            hasGeocoded.All(x => x.Latitude == double.Parse(x.Address) * 2 && x.Longitude == double.Parse(x.Address) * 2 && x.FormattedAddress == x.GeoAddress.Replace('_', ' ')).Should().BeTrue();
+        }
+
 
         [Test]
         public void WithAResult()
@@ -68,18 +144,18 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Geocoder
                 }))
                 .Verifiable();
 
-            context.Locations.Add(new Location{ GeoAddress = "FakeStreet", Address = "old address that will no longer get geo coded" });
+            context.Locations.Add(new Location{ GeoAddress = "FakeStreet", Address = "old address that will  get geo coded" });
             context.SaveChanges();
 
             system.RequestLocations().Wait();
 
             httpClient.VerifyAll();
             var res = context.Locations.Single();
-            Assert.AreEqual("FakeStreet", res.GeoAddress);
-            Assert.AreEqual("old address that will no longer get geo coded", res.Address);
-            Assert.AreEqual("Formatted fake street", res.FormattedAddress);
-            Assert.AreEqual(12.3, res.Latitude);
-            Assert.AreEqual(23.1, res.Longitude);
+            res.GeoAddress.Should().Be("FakeStreet");
+            res.Address.Should().Be("old address that will no longer get geo coded");
+            res.FormattedAddress.Should().Be("Formatted fake street");
+            res.Latitude.Should().Be(12.3);
+            res.Longitude.Should().Be(23.1);
 
             Assert.LessOrEqual(startTime, res.LastGeocodedUtc);
             Assert.GreaterOrEqual(DateTime.UtcNow, res.LastGeocodedUtc);
@@ -91,7 +167,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Geocoder
             httpClient.Setup(x => x.GetAsync(It.IsAny<string>()))
                 .ThrowsAsync(new Exception("shouldn't be called"));
 
-            context.Locations.Add(new Location { Address = "FakeStreet", FormattedAddress = "Formatted fake street", Latitude = 12.3, Longitude = 23.1});
+            context.Locations.Add(new Location { GeoAddress = "GeoAddress", Address = "FakeStreet", FormattedAddress = "Formatted fake street", Latitude = 12.3, Longitude = 23.1, LastGeocodedUtc = DateTime.Now});
             context.SaveChanges();
 
             Assert.DoesNotThrowAsync(() => system.RequestLocations());

--- a/tests/Integration.Tests/Geocoder/LocationRequester.Tests.cs
+++ b/tests/Integration.Tests/Geocoder/LocationRequester.Tests.cs
@@ -144,7 +144,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Geocoder
                 }))
                 .Verifiable();
 
-            context.Locations.Add(new Location{ GeoAddress = "FakeStreet", Address = "old address that will  get geo coded" });
+            context.Locations.Add(new Location{ GeoAddress = "FakeStreet", Address = "address not will get geo coded any more" });
             context.SaveChanges();
 
             var result = system.RequestLocations().Result;
@@ -153,7 +153,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Geocoder
             httpClient.VerifyAll();
             var res = context.Locations.Single();
             res.GeoAddress.Should().Be("FakeStreet");
-            res.Address.Should().Be("old address that will no longer get geo coded");
+            res.Address.Should().Be("address not will get geo coded any more");
             res.FormattedAddress.Should().Be("Formatted fake street");
             res.Latitude.Should().Be(12.3);
             res.Longitude.Should().Be(23.1);


### PR DESCRIPTION
### Context
**Note a failure is a failure, as well as partial failure is still a failure, hiding a failure is still a failure, so do not be a failure by hiding a failure, that is such a failure**

No one looks at the logs so no one knows that there is a location that has failed to geocode.

Success is no longer a guarantee to denote a unresolved geo coding.

### Changes proposed in this pull request
Added additional logging
Added telemetry to denote error for failures for failed geo coding
Fixed the geo coder to be take in account lack of LastGeocodedUtc
Amended to denote that its a failure via exit code based on count of failures,


