### PR TITLE
Fix orphaned campus records on publish

### DIFF
--- a/src/api/DatabaseAccess/CourseDbContext.cs
+++ b/src/api/DatabaseAccess/CourseDbContext.cs
@@ -77,6 +77,12 @@ namespace GovUk.Education.SearchAndCompare.Api.DatabaseAccess
                 .WithMany(c => c.CourseSubjects)
                 .HasForeignKey(cs => cs.SubjectId);
 
+            //cascade delete between Course Campuses
+            modelBuilder.Entity<Campus>()
+                .HasOne(p => p.Course)
+                .WithMany(b => b.Campuses)
+                .OnDelete(DeleteBehavior.Cascade);
+
             modelBuilder.Entity<DefaultCourseDescriptionSection>();
 
             base.OnModelCreating(modelBuilder);

--- a/src/api/DatabaseAccess/CourseDbContext.cs
+++ b/src/api/DatabaseAccess/CourseDbContext.cs
@@ -79,8 +79,8 @@ namespace GovUk.Education.SearchAndCompare.Api.DatabaseAccess
 
             //cascade delete between Course Campuses
             modelBuilder.Entity<Campus>()
-                .HasOne(p => p.Course)
-                .WithMany(b => b.Campuses)
+                .HasOne(c => c.Course)
+                .WithMany(c => c.Campuses)
                 .OnDelete(DeleteBehavior.Cascade);
 
             modelBuilder.Entity<DefaultCourseDescriptionSection>();

--- a/src/api/Migrations/20181213160201_ClearOrphanedCampusRecords.Designer.cs
+++ b/src/api/Migrations/20181213160201_ClearOrphanedCampusRecords.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using GovUk.Education.SearchAndCompare.Api.DatabaseAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace SearchAndCompare.Migrations
 {
     [DbContext(typeof(CourseDbContext))]
-    partial class CourseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20181213160201_ClearOrphanedCampusRecords")]
+    partial class ClearOrphanedCampusRecords
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/api/Migrations/20181213160201_ClearOrphanedCampusRecords.cs
+++ b/src/api/Migrations/20181213160201_ClearOrphanedCampusRecords.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace SearchAndCompare.Migrations
+{
+    public partial class ClearOrphanedCampusRecords : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("delete from campus where \"CourseId\" is null;");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            //do nuffink
+        }
+    }
+}

--- a/tests/Integration.Tests/Controllers/SaveSingleCourse_CoursesController.Tests.cs
+++ b/tests/Integration.Tests/Controllers/SaveSingleCourse_CoursesController.Tests.cs
@@ -298,11 +298,11 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
         public void ImportSameCoursesTwice()
         {
             var course = GetCourses(1).First();
-            var result1 = subject.SaveCourses(new List<Course> { course }).Result;;
+            var result1 = subject.SaveCourses(new List<Course> { course }).Result;
             AssertOkay(result1);
 
             var course2 = GetCourses(1).First();
-            var result2 = subject.SaveCourses(new List<Course>{course2}).Result;;
+            var result2 = subject.SaveCourses(new List<Course>{course2}).Result;
             AssertOkay(result2);
 
             var resultingCourses = context.GetCoursesWithProviderSubjectsRouteAndCampuses().ToList();
@@ -322,9 +322,9 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
             var expectedLocations = GetExpectedLocations(courses);
             context.Locations.Count().Should().Be(expectedLocations.Count());
             context.Campuses.Count().Should().Be(4); //definately right
-            context.Contacts.Count().Should().Be(2); //probably wrong
 
             // non-deduplicated            
+            context.Contacts.Count().Should().Be(2); //probably wrong
             context.CourseSubjects.Count().Should().Be(1);            
         }
 
@@ -549,7 +549,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
                     Salary = new Salary(),
 
                     // need the full object
-                    ContactDetails = new Contact(),
+                    ContactDetails = new Contact{Email = "commonContact@example.com"},
 
                     // need the address part
                     ProviderLocation = new Location

--- a/tests/Integration.Tests/Controllers/SaveSingleCourse_CoursesController.Tests.cs
+++ b/tests/Integration.Tests/Controllers/SaveSingleCourse_CoursesController.Tests.cs
@@ -549,7 +549,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
                     Salary = new Salary(),
 
                     // need the full object
-                    ContactDetails = new Contact{Email = "commonContact@example.com"},
+                    ContactDetails = new Contact(),
 
                     // need the address part
                     ProviderLocation = new Location

--- a/tests/Integration.Tests/Controllers/SaveSingleCourse_CoursesController.Tests.cs
+++ b/tests/Integration.Tests/Controllers/SaveSingleCourse_CoursesController.Tests.cs
@@ -321,11 +321,11 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
             context.Subjects.Count().Should().Be(1);
             var expectedLocations = GetExpectedLocations(courses);
             context.Locations.Count().Should().Be(expectedLocations.Count());
-
-            // non-deduplicated
-            context.Campuses.Count().Should().Be(8); //probably wrong
-            context.CourseSubjects.Count().Should().Be(1);
+            context.Campuses.Count().Should().Be(4); //definately right
             context.Contacts.Count().Should().Be(2); //probably wrong
+
+            // non-deduplicated            
+            context.CourseSubjects.Count().Should().Be(1);            
         }
 
         [Test]


### PR DESCRIPTION
### Context
On publishing a course all of the existing campus records are left in an orphaned state ie the course id is set to null. Here is the card for this:
https://trello.com/c/PV6njHQJ/785-multiple-campus-records-created-on-publish

### Changes proposed in this pull request
Added a cascading delete to the context model builder.
Fixed test that would have revealed this issue if the assertions had been correct.
### Guidance to review
if you want to run this and see for yourself then:
1) Drop your local SearchAndCompare database
2) Change to the master branch for the SearchAndCompare api solution
3) Fire up the SearchAndCompare api (point to the local db)
4) Fire up manage course api and ui.
5) Publish a course, make a change and publish it again
6) Run this query on the SearchAndCompare api database "select * from campus;"
7) Notice there are campus records with null course Ids.
Change to this Pr branch and repeat everything.
There now should be no campus records with null course Ids.