### PR TITLE
Kill prod3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,9 @@ deploy:
     HEAD:refs/heads/master
   on: staging
 - provider: script
-  script: git fetch --unshallow && git push --force https://govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD@bat-prod-search-and-compare-api-app.scm.azurewebsites.net:443/bat-prod-search-and-compare-api-app.git HEAD:refs/heads/master
-  on: production
-- provider: script
-  script: git fetch --unshallow && git push --force https://govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD@bat-prod3-search-and-compare-api-app.scm.azurewebsites.net:443/bat-prod3-search-and-compare-api-app.git HEAD:refs/heads/master
+  script: 
+  - git fetch --unshallow && git push --force https://govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD@bat-prod-search-and-compare-api-app.scm.azurewebsites.net:443/bat-prod-search-and-compare-api-app.git HEAD:refs/heads/master
+  - git fetch --unshallow && git push --force https://govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD@bat-prod3-search-and-compare-api-app.scm.azurewebsites.net:443/bat-prod3-search-and-compare-api-app.git HEAD:refs/heads/master
   on: production
 - provider: script
   script: "./travis-deploy-geocoder.sh govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD
@@ -43,7 +42,7 @@ deploy:
     bat-staging-search-and-compare-api-app"
   on: staging
 - provider: script
-  script:
+  script: 
   - "./travis-deploy-geocoder.sh govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD bat-prod-search-and-compare-api-app"
   - "./travis-deploy-geocoder.sh govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD bat-prod3-search-and-compare-api-app"
   on: production

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,8 @@ deploy:
     HEAD:refs/heads/master
   on: staging
 - provider: script
-  script: 
-  - git fetch --unshallow && git push --force https://govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD@bat-prod-search-and-compare-api-app.scm.azurewebsites.net:443/bat-prod-search-and-compare-api-app.git HEAD:refs/heads/master
-  - git fetch --unshallow && git push --force https://govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD@bat-prod3-search-and-compare-api-app.scm.azurewebsites.net:443/bat-prod3-search-and-compare-api-app.git HEAD:refs/heads/master
+  script: git fetch --unshallow && git push --force https://govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD@bat-prod-search-and-compare-api-app.scm.azurewebsites.net:443/bat-prod-search-and-compare-api-app.git
+    HEAD:refs/heads/master
   on: production
 - provider: script
   script: "./travis-deploy-geocoder.sh govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD
@@ -42,9 +41,8 @@ deploy:
     bat-staging-search-and-compare-api-app"
   on: staging
 - provider: script
-  script: 
-  - "./travis-deploy-geocoder.sh govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD bat-prod-search-and-compare-api-app"
-  - "./travis-deploy-geocoder.sh govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD bat-prod3-search-and-compare-api-app"
+  script: "./travis-deploy-geocoder.sh govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD
+    bat-prod-search-and-compare-api-app"
   on: production
 - provider: script
   skip_cleanup: true


### PR DESCRIPTION
### Context

Deploy to prod isn't working. Prod3 isn't needed at the moment so unblock deploy by reverting the prod3 travis config.

Tried to fix it but ran into duplicate prod3 error.

### Changes proposed in this pull request

Revert prod3 addition
