### PR TITLE
Remove backslash in query plus tests

### DIFF
--- a/src/api/DatabaseAccess/CourseDbContext.cs
+++ b/src/api/DatabaseAccess/CourseDbContext.cs
@@ -257,7 +257,7 @@ SELECT * FROM (
     GROUP BY ""provider"".""Id"") AS sub
 ORDER BY lower(""Name"") <> lower(@query) ASC, ""cnt"" DESC
 LIMIT @limit",
-            new NpgsqlParameter("@query", query),
+            new NpgsqlParameter("@query", query.Replace(@"\","")),
             new NpgsqlParameter("@limit", 5))
             .ToList();
         }

--- a/tests/Integration.Tests/DatabaseAccess/CourseDbContextIntegrationTests.cs
+++ b/tests/Integration.Tests/DatabaseAccess/CourseDbContextIntegrationTests.cs
@@ -164,6 +164,8 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.DatabaseA
                 Assert.AreEqual(0, context2.SuggestProviders("provider foobar").Count(), "multiwords bad");
                 Assert.AreEqual(2, context2.SuggestProviders("provider my").Count(), "multiwords good");
                 Assert.AreEqual(2, context2.SuggestProviders("prov my").Count(), "multiwords good incomplete");
+                Assert.AreEqual(2, context2.SuggestProviders(@"provider my\").Count(), "multiwords good");
+                Assert.AreEqual(2, context2.SuggestProviders(@"prov my\").Count(), "multiwords good incomplete");
             }
         }
 


### PR DESCRIPTION
### Context
A 500 is return when there is a trailing backslash and the end of a search string.
Here is the trello card:
https://trello.com/c/gPYhnnBz/700-error-for-trailing-slash-in-provider-name-search
A concern was raised of a potential security issue around sql injection possibility in this block of code.
However on further reading I am satisfied this is not the case as we are using parameters for the query and also using the full text search functionality in postgres that transforms the query string into search parameters. 
### Changes proposed in this pull request
Filter out any backslashes in the query parameter
