### PR TITLE
[1032] Circuit breaker for preventing massive change in course count

### DIFF
--- a/src/api/Controllers/CoursesController.cs
+++ b/src/api/Controllers/CoursesController.cs
@@ -99,8 +99,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
         [RequestSizeLimit(100_000_000_000)]
         public IActionResult Index([FromBody]IList<Course> courses)
         {
-            // circuit breaker for empty post
-            if (courses == null || !courses.Any())
+            if (CircuitBreakerTripped(courses))
             {
                 return BadRequest();
             }
@@ -115,19 +114,6 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
             if (ModelState.IsValid &&
                 courses.All(x => x.IsValid(false)))
             {
-                // circuit breaker for wildly different number of courses
-                var current = _context.Courses.Count();
-                if (current != 0) // empty database so skip the sanity check. This is useful for populating a local test system, or reconstructing production after a fire
-                {
-                    var incoming = courses.Count;
-                    var difference = incoming - current; // e.g. 100 existing, 98 incoming = difference of -2, i.e. there will be two less courses on find when completed
-                    const int maxDifference = 500; // todo: get from config, tune to realistic numbers. think about potential spikes at rollover etc
-                    if (Math.Abs(difference) > maxDifference)
-                    {
-                        _logger.LogError($"Refusing to update course list, difference of {difference} exceeded circuit breaker max of {maxDifference}");
-                        return BadRequest();
-                    }
-                }
                 var success = false;
                 // Strategy is required for compatibility with EnableRetryOnFailure in Startup. Ref https://docs.microsoft.com/en-gb/azure/architecture/best-practices/retry-service-specific#sql-database-using-entity-framework-core
                 var strategy = ((DbContext)_context).Database.CreateExecutionStrategy();
@@ -187,6 +173,40 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Return true if threshold exceeded so that we can halt the update.
+        /// </summary>
+        /// <param name="receivedCourses"></param>
+        /// <returns>true if threshold exceeded, false if all seems okay</returns>
+        private bool CircuitBreakerTripped(ICollection<Course> receivedCourses)
+        {
+            // circuit breaker for empty post
+            if (receivedCourses == null || !receivedCourses.Any())
+            {
+                return true;
+            }
+
+            var current = _context.Courses.Count();
+
+            if (current == 0)
+            {
+                // empty database so skip the sanity check. This is useful for populating a local test system, or reconstructing production after a fire
+                return false;
+            }
+
+            // circuit breaker for wildly different number of courses
+            var incoming = receivedCourses.Count;
+            var changeInCourseCount = incoming - current; // e.g. 100 existing, 98 incoming = difference of -2, i.e. there will be two less courses on find when completed
+            const int maxDifference = 500; // todo: get from config, tune to realistic numbers. think about potential spikes at rollover etc
+            if (Math.Abs(changeInCourseCount) <= maxDifference)
+            {
+                return false;
+            }
+
+            _logger.LogError( $"Refusing to update course list, difference of {changeInCourseCount} exceeded circuit breaker max of {maxDifference}");
+            return true;
         }
 
         [HttpGet("total")]

--- a/tests/Integration.Tests/Controllers/CoursesController.Tests.cs
+++ b/tests/Integration.Tests/Controllers/CoursesController.Tests.cs
@@ -19,6 +19,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using GovUk.Education.SearchAndCompare.Domain.Lists;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 
 namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controllers
 {
@@ -31,7 +32,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
         public void Setup()
         {
             var loggerMock = new Mock<ILogger<CoursesController>>();
-            subject = new CoursesController(context, loggerMock.Object);
+            subject = new CoursesController(context, loggerMock.Object, new Mock<IConfiguration>().Object);
         }
 
         [Test]

--- a/tests/Integration.Tests/Controllers/Pub.Tests.cs
+++ b/tests/Integration.Tests/Controllers/Pub.Tests.cs
@@ -16,6 +16,7 @@ using GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.DatabaseAcces
 using System.Collections.ObjectModel;
 using Microsoft.EntityFrameworkCore;
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controllers
@@ -29,7 +30,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
         public void Setup()
         {
             var loggerMock = new Mock<ILogger<CoursesController>>();
-            subject = new CoursesController(context, loggerMock.Object);
+            subject = new CoursesController(context, loggerMock.Object, new Mock<IConfiguration>().Object);
         }
 
 

--- a/tests/Integration.Tests/Controllers/SaveSingleCourse_CoursesController.Tests.cs
+++ b/tests/Integration.Tests/Controllers/SaveSingleCourse_CoursesController.Tests.cs
@@ -18,6 +18,7 @@ using GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.DatabaseAcces
 using System.Collections.ObjectModel;
 using Microsoft.EntityFrameworkCore;
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controllers
@@ -31,7 +32,7 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.Controlle
         public void Setup()
         {
             var loggerMock = new Mock<ILogger<CoursesController>>();
-            subject = new CoursesController(context, loggerMock.Object);
+            subject = new CoursesController(context, loggerMock.Object, new Mock<IConfiguration>().Object);
         }
 
         [TearDown]


### PR DESCRIPTION
### Context

Previous failures dropped 100% and ~10% of courses due to failures in import/manage courses. We have already prevented a 100% drop but smaller failures aren't protected against cascading from manage to find.

We could do this on the sending side but it seems more robust to do it here.

This PR doesn't cover how to configure acceptable / expected ranges. It raises issues around how to handle big expected spikes, and what it means to manage good/bad ratios.

I'm not 100% convinced by this change at the moment in terms of protecting against failure vs the overhead of constantly maintaining the boundaries and the cost of false positives (partly in terms of the numbing effect of too many false positives)


### Changes proposed in this pull request

Proof of concept circuit breaker logic, not tested yet. Throws if outside limits, this will propagate to app insights which we could then alert from.

### Guidance to review
