### PR TITLE
[1579] Fix dependency injection for geocoder

### DIFF
--- a/src/api/Startup.cs
+++ b/src/api/Startup.cs
@@ -75,7 +75,7 @@ namespace GovUk.Education.SearchAndCompare.Api
                 .Enrich.WithProperty("Identifer", Guid.NewGuid())
                 .CreateLogger());
 
-            services.AddSingleton<ILocationRequester, LocationRequester>();
+            services.AddScoped<ILocationRequester, LocationRequester>();
 
             // No default auth method has been set here because each action must explicitly be decorated with
             // ApiTokenAuthAttribute.


### PR DESCRIPTION
This was breaking the synchronise from publish to search and compare.
It seems there's been a change in the dotnet runtime that caused this to
start failing. LocationRequester was a singleton depending on the scoped
dbcontext service which actually doesn't make sense from a scoping point
of view.

> System.InvalidOperationException: Cannot consume scoped service
> 'GovUk.Education.SearchAndCompare.Api.DatabaseAccess.ICourseDbContext'
> from singleton
> 'GovUk.Education.SearchAndCompare.Geocoder.ILocationRequester'.

By making the geocoder use the same scope rule as the dbcontext they now
line up and this stops failing.

### Context

### Changes proposed in this pull request

### Guidance to review
