### PR TITLE
[1581] Add additional course info to circuit breaker

### DIFF
--- a/src/api/Controllers/CoursesController.cs
+++ b/src/api/Controllers/CoursesController.cs
@@ -227,9 +227,14 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
             var changeInCourseCount = receivedCourses.Count - currentCourseCount; // e.g. 100 existing, 98 incoming = difference of -2, i.e. there will be two less courses on find when completed
             var absDiff = Math.Abs(changeInCourseCount);
             var reason = $"Received {absDiff} " + (receivedCourses.Count > currentCourseCount ? "new courses" : "less courses");
+            var coursesAddedOrRemoved = changeInCourseCount > 0 ? "added" : "removed";
+            var changedCourseInfos = (changeInCourseCount > 0 ? receivedCourses.ToList() : _context.Courses.ToList())
+              .Skip((changeInCourseCount > 0 ? receivedCourses.Count : _context.Courses.Count()) - 5)
+              .Select(x => $"{x.Provider.ProviderCode}/{x.ProgrammeCode}");
             if (absDiff > maxDifference)
             {
                 _logger.LogError($"CircuitBreakerTripped: Change exceeded {limitKey}={maxDifference}. {reason}."
+                    + $"\nLast 5 course IDs being {coursesAddedOrRemoved}: {string.Join(", ", changedCourseInfos)}"
                     + $"\nCurrent courses {currentCourseCount}, received courses {receivedCourseCount}.");
                 return true;
             }


### PR DESCRIPTION
### Context

When the circuit breaker trips, we can see the number of added or removed courses. It would be useful to also see the providerCode/courseCode tuples of some courses that have been added/removed.

### Changes proposed in this pull request

I'm not sure what the ordering of `_context.Courses` or `receivedCourses` is and whether this will produce an actual useful output, but assuming that they are ordered by the `updated_at` or the `id`, then this should work to output the course codes for the last 5 added or removed courses.

### Guidance to review

I have not tested this, but it compiles; this means at least all the method calls are returning sane things and this will output a string successfully. Whether it contains actual usable info or will just be a red herring, I'm not sure.