### PR TITLE
[1581] Added additional logging

### DIFF
--- a/src/api/Helpers/CoursesDiffDetails.cs
+++ b/src/api/Helpers/CoursesDiffDetails.cs
@@ -1,0 +1,22 @@
+using GovUk.Education.SearchAndCompare.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GovUk.Education.SearchAndCompare.Api.Helpers
+{
+
+    public class CoursesDiffDetails
+    {
+
+        public CoursesDiffDetails(IList<string> currentCourses, IList<string> recievedCourses)
+        {
+            Removed = currentCourses.Except(recievedCourses).ToList();
+            Added = recievedCourses.Except(currentCourses).ToList();
+        }
+
+        public IList<string> Added {get;}
+        public IList<string> Removed {get;}
+    }
+}

--- a/tests/Unit.Tests/CoursesDiffDetailsTests.cs
+++ b/tests/Unit.Tests/CoursesDiffDetailsTests.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.SearchAndCompare.Api.ListExtensions;
+using GovUk.Education.SearchAndCompare.Api.Helpers;
+using GovUk.Education.SearchAndCompare.Domain.Models;
+using MockQueryable.Moq;
+using NUnit.Framework;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.SearchAndCompare.Api.Tests.Unit.Tests
+{
+    [TestFixture]
+    public class CoursesDiffDetailsTests
+    {
+
+        public IList<string> GetCourses(int noOfCourses = 1, string programmeCodePrefix = "ProgrammeCode" )
+        {
+            var result = new List<Course>();
+            for (int i = 1; i <= noOfCourses; i++)
+            {
+                var provider = new Provider() {ProviderCode = "ProviderCode"};
+                var course = new Course() {ProgrammeCode =  programmeCodePrefix + i, Provider = provider};
+                result.Add(course);
+            }
+
+            return result.Select(course => $"[{course.Provider.ProviderCode}, {course.ProgrammeCode}]").OrderBy(x => x).ToList();
+        }
+
+        [Test]
+        public void Added()
+        {
+            var currentCourses = GetCourses();
+            var recievedCourses = GetCourses(2);
+
+            var diff1 = new CoursesDiffDetails(currentCourses, recievedCourses);
+
+            Assert.That(diff1.Added.FirstOrDefault(x => x.Equals("[ProviderCode, ProgrammeCode2]")), Is.Not.Null);
+            Assert.That(diff1.Added.Count == 1, Is.True);
+            Assert.That(diff1.Removed.Count == 0, Is.True);
+        }
+
+        [Test]
+        public void Removed()
+        {
+            var currentCourses = GetCourses(2);
+            var recievedCourses = GetCourses();
+
+            var diff1 = new CoursesDiffDetails(currentCourses, recievedCourses);
+
+            Assert.That(diff1.Removed.FirstOrDefault(x => x.Equals("[ProviderCode, ProgrammeCode2]")), Is.Not.Null);
+            Assert.That(diff1.Removed.Count == 1, Is.True);
+            Assert.That(diff1.Added.Count == 0, Is.True);
+        }
+
+        [Test]
+        public void RemovedAndAdded()
+        {
+            var currentCourses = GetCourses(1, "current");
+            var recievedCourses = GetCourses(1, "recieved");
+
+            var diff1 = new CoursesDiffDetails(currentCourses, recievedCourses);
+
+            Assert.That(diff1.Removed.FirstOrDefault(x => x.Equals("[ProviderCode, current1]")), Is.Not.Null);
+            Assert.That(diff1.Removed.Count == 1, Is.True);
+
+            Assert.That(diff1.Added.FirstOrDefault(x => x.Equals("[ProviderCode, recieved1]")), Is.Not.Null);
+            Assert.That(diff1.Added.Count == 1, Is.True);
+        }
+
+        [Test]
+        public void NoChange()
+        {
+            var currentCourses = GetCourses(10);
+            var recievedCourses = GetCourses(10);
+
+            var diff1 = new CoursesDiffDetails(currentCourses, recievedCourses);
+
+            Assert.That(diff1.Removed.Count == 0, Is.True);
+            Assert.That(diff1.Added.Count == 0, Is.True);
+        }
+    }
+}


### PR DESCRIPTION
### Context
Additional info for when bulk uploading courses

### Changes proposed in this pull request
Before the trip log it and send a postcard to logger

### Guidance to review

where x is  `[ProviderCode, CourseCode]`
where y is `total of added courses`
where z is `total of removed courses`
`CircuitBreaker Diff: [Removed:, [x,...]`
`CircuitBreaker Diff: [Added:, [x,...]`

`CircuitBreaker Diff: [Summary:, [[Added: y], [Removed: z]]]`

![image](https://user-images.githubusercontent.com/470137/59043594-6bf03900-8874-11e9-96b6-689b57f02461.png)

