### PR TITLE
Enable App Service Logs for the service

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -344,6 +344,29 @@
             ]
         },
         {
+            "name": "app-service-logs",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2017-05-10",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'), 'app-service-logs.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "appServiceName": {
+                        "value": "[variables('appServiceName')]"
+                    },
+                    "httpLoggingEnabled": {
+                        "value": true
+                    }
+                }
+            },
+            "dependsOn": [
+                "app-service"
+            ]
+        },
+        {
             "name": "worker-app-service-plan",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2017-05-10",

--- a/azure/template.json
+++ b/azure/template.json
@@ -357,7 +357,16 @@
                     "appServiceName": {
                         "value": "[variables('appServiceName')]"
                     },
+                    "applicationLogsFileSystem": {
+                        "value": "Error"
+                    },
                     "httpLoggingEnabled": {
+                        "value": true
+                    },
+                    "requestTracingEnabled": {
+                        "value": true
+                    },
+                    "detailedErrorLoggingEnabled": {
                         "value": true
                     }
                 }


### PR DESCRIPTION
### Context
Enable App Service Logs for the service.

### Changes proposed in this pull request
Add a resource deployment to the apps ARM template that references the App Service Log building block.
