### PR TITLE
[xxxx] Proritise providers starting with query

### DIFF
--- a/src/api/DatabaseAccess/CourseDbContext.cs
+++ b/src/api/DatabaseAccess/CourseDbContext.cs
@@ -255,14 +255,23 @@ SELECT * FROM (
     WHERE (to_tsvector('english', ""provider"".""Name"") @@ to_tsquery('english', quote_literal(@query) || ':*')) IS TRUE
     OR (to_tsvector('english', ""provider"".""ProviderCode"") @@ to_tsquery('english', quote_literal(@query) || ':*')) IS TRUE
     GROUP BY ""provider"".""Id"") AS sub
-ORDER BY lower(""Name"") <> lower(@query) ASC, ""cnt"" DESC",
-            new NpgsqlParameter("@query", query.Replace(@"\","")),
-            new NpgsqlParameter("@limit", 5))
+ORDER BY ""cnt"" DESC",
+            new NpgsqlParameter("@query", query.Replace(@"\","")))
             .ToList();
 
-            var matchedProviders = providers.Where(p => p.Name.StartsWith(query));
-            var nonMatchedProviders = providers.Where(p => !p.Name.StartsWith(query));
-            return matchedProviders.Concat(nonMatchedProviders).Take(5).ToList();
+
+            /*
+             * When there are multiple providers with common words in, the provider a user is searching for might 
+             * not appear on the list.
+             *
+             * An example of this was "Teach North", where it would match on things like "Teaching Alliance (North)"
+             *
+             * The below prioritises providers whose name starts with the given search query
+             */
+
+            var providersStartingWithQuery = providers.Where(p => p.Name.ToLower().StartsWith(query.ToLower()));
+            var providersNotStartingWithquery = providers.Where(p => !p.Name.ToLower().StartsWith(query.ToLower()));
+            return providersStartingWithQuery.Concat(providersNotStartingWithquery).Take(5).ToList();
         }
 
         private IQueryable<Course> ForListing(IQueryable<Course> queryable)

--- a/tests/Integration.Tests/DatabaseAccess/CourseDbContextIntegrationTests.cs
+++ b/tests/Integration.Tests/DatabaseAccess/CourseDbContextIntegrationTests.cs
@@ -187,8 +187,9 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.DatabaseA
 
           using (var context2 = GetContext())
           {
-            var courses = context2.SuggestProviders("SCITT");
-            Assert.AreEqual("SCITT provider", courses.First().Name);
+            var providers = context2.SuggestProviders("scitt");
+            Assert.AreEqual("SCITT provider", providers.First().Name);
+            Assert.AreEqual(2, providers.Count);
           }
         }
 

--- a/tests/Integration.Tests/DatabaseAccess/CourseDbContextIntegrationTests.cs
+++ b/tests/Integration.Tests/DatabaseAccess/CourseDbContextIntegrationTests.cs
@@ -170,6 +170,29 @@ namespace GovUk.Education.SearchAndCompare.Api.Tests.Integration.Tests.DatabaseA
         }
 
         [Test]
+        public void SuggestProviders_PrioritiseMatching()
+        {
+          Assert.AreEqual(0, context.Courses.Count());
+
+          var courseOne = GetSimpleCourse();
+          courseOne.Provider.Name = "provider SCITT";
+          var entityOne = context.Courses.Add(courseOne);
+          var courseTwo = GetSimpleCourse();
+          courseTwo.Provider.Name = "SCITT provider";
+          var entityTwo = context.Courses.Add(courseTwo);
+          context.SaveChanges();
+
+          entitiesToCleanUp.Add(entityOne);
+          entitiesToCleanUp.Add(entityTwo);
+
+          using (var context2 = GetContext())
+          {
+            var courses = context2.SuggestProviders("SCITT");
+            Assert.AreEqual("SCITT provider", courses.First().Name);
+          }
+        }
+
+        [Test]
         [TestCase("xyz", 1)]
         [TestCase("wxy", 1)]
         [TestCase("xxx", 0)]


### PR DESCRIPTION
### Context

Providers were noticing that their names should appear higher when searching for their name directly

### Changes proposed in this pull request

Prioritize partial matching at the start of the string

### Guidance to review
