### PR TITLE
[2526] Improve circuit breaker logging and set default limit

### DIFF
--- a/src/api/Controllers/CoursesController.cs
+++ b/src/api/Controllers/CoursesController.cs
@@ -198,75 +198,8 @@ namespace GovUk.Education.SearchAndCompare.Api.Controllers
         /// <returns>true if threshold exceeded, false if all seems okay</returns>
         private bool CircuitBreakerTripped(ICollection<Course> receivedCourses)
         {
-            var currentCourseCount = _context.Courses.Count();
-            var receivedCourseCount = receivedCourses?.Count ?? 0;
-            _logger.LogInformation($"Circuit breaker: Current courses {currentCourseCount}, received courses {receivedCourseCount}.");
-
-            // circuit breaker for empty post
-            if (receivedCourses == null || !receivedCourses.Any())
-            {
-                _logger.LogError( "CircuitBreakerTripped: empty course list received");
-                return true;
-            }
-
-
-            if (currentCourseCount == 0)
-            {
-                _logger.LogInformation( "CircuitBreaker: bypassing checks as there are no courses in the database.");
-                // This is useful for populating a local test system, or reconstructing production after a fire
-                return false;
-            }
-
-            const string limitKey = "CIRCUIT_BREAKER_COURSE_LIMIT";
-            var maxDifferenceString = _configuration[limitKey];
-            if (string.IsNullOrWhiteSpace(maxDifferenceString))
-            {
-                _logger.LogWarning( $"CircuitBreaker: bypassing checks as no limit configured. Configure with: {limitKey}");
-                return false;
-            }
-
-            var courseInfoFormat = "[{0}, {1}]";
-
-            var recieved = receivedCourses
-                .Select(course => string.Format(courseInfoFormat, course.Provider != null ? course.Provider.ProviderCode : null, course.ProgrammeCode))
-                .OrderBy(x => x)
-                .ToList();
-            var current = _context.Courses
-                .Select(course => string.Format(courseInfoFormat, course.Provider != null ? course.Provider.ProviderCode : null, course.ProgrammeCode))
-                .OrderBy(x => x)
-                .ToList();
-
-            var diff = new CoursesDiffDetails(current, recieved);
-
-            var changes = $"[Added: {diff.Added.Count()}], [Removed: {diff.Removed.Count()}]";
-
-            var diffMsgFormat = "CircuitBreaker Diff: [{0}:, [{1}]]";
-            _logger.LogInformation(string.Format(diffMsgFormat, "Summary", changes));
-
-            if(diff.Added.Any())
-            {
-                _logger.LogInformation(string.Format(diffMsgFormat, "Added", string.Join(",", diff.Added)));
-            }
-
-            if(diff.Removed.Any())
-            {
-                _logger.LogInformation(string.Format(diffMsgFormat, "Removed", string.Join(",", diff.Removed)));
-            }
-
-            var maxDifference = int.Parse(maxDifferenceString);
-            var changeInCourseCount = receivedCourses.Count - currentCourseCount; // e.g. 100 existing, 98 incoming = difference of -2, i.e. there will be two less courses on find when completed
-            var absDiff = Math.Abs(changeInCourseCount);
-            var reason = $"Received {absDiff} " + (receivedCourses.Count > currentCourseCount ? "new courses" : "less courses");
-            if (absDiff > maxDifference)
-            {
-                _logger.LogError($"CircuitBreakerTripped: Change exceeded {limitKey}={maxDifference}. {reason}."
-                    + $"\nCurrent courses {currentCourseCount}, received courses {receivedCourseCount}.");
-
-                return true;
-            }
-
-            // all checks passed
-            return false;
+            var circuitBreaker = new CircuitBreaker(_context.Courses, _logger, _configuration);
+            return circuitBreaker.Run(receivedCourses);
         }
 
         [HttpGet("total")]

--- a/src/api/Helpers/CircuitBreaker.cs
+++ b/src/api/Helpers/CircuitBreaker.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.SearchAndCompare.Domain.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.SearchAndCompare.Api.Helpers
+{
+    public class CircuitBreaker
+    {
+        private readonly IQueryable<Course> _existingCourses;
+        private readonly ILogger _logger;
+        private readonly IConfiguration _configuration;
+
+        public CircuitBreaker(IQueryable<Course> existingCourses, ILogger logger, IConfiguration configuration)
+        {
+            _existingCourses = existingCourses;
+            _logger = logger;
+            _configuration = configuration;
+        }
+
+        /// <summary>
+        /// Return true if threshold exceeded so that we can halt the update.
+        /// </summary>
+        /// <param name="receivedCourses"></param>
+        /// <returns>true if threshold exceeded, false if all seems okay</returns>
+        public bool Run(ICollection<Course> receivedCourses)
+        {
+            var currentCourseCount = _existingCourses.Count();
+            var receivedCourseCount = receivedCourses?.Count ?? 0;
+            _logger.LogInformation($"Circuit breaker: Current courses {currentCourseCount}, received courses {receivedCourseCount}.");
+
+            // circuit breaker for empty post
+            if (receivedCourses == null || !receivedCourses.Any())
+            {
+                _logger.LogError( "CircuitBreakerTripped: empty course list received");
+                return true;
+            }
+
+            if (currentCourseCount == 0)
+            {
+                _logger.LogInformation( "CircuitBreaker: bypassing checks as there are no courses in the database.");
+                // This is useful for populating a local test system, or reconstructing production after a fire
+                return false;
+            }
+
+            const string limitKey = "CIRCUIT_BREAKER_COURSE_LIMIT";
+            var maxDifferenceString = _configuration[limitKey];
+            if (string.IsNullOrWhiteSpace(maxDifferenceString))
+            {
+                _logger.LogWarning( $"CircuitBreaker: bypassing checks as no limit configured. Configure with: {limitKey}");
+                return false;
+            }
+
+            var courseInfoFormat = "[{0}, {1}]";
+
+            var recieved = receivedCourses
+                .Select(course => string.Format(courseInfoFormat, course.Provider != null ? course.Provider.ProviderCode : null, course.ProgrammeCode))
+                .OrderBy(x => x)
+                .ToList();
+            var current = _existingCourses
+                .Select(course => string.Format(courseInfoFormat, course.Provider != null ? course.Provider.ProviderCode : null, course.ProgrammeCode))
+                .OrderBy(x => x)
+                .ToList();
+
+            var diff = new CoursesDiffDetails(current, recieved);
+
+            var changes = $"[Added: {diff.Added.Count()}], [Removed: {diff.Removed.Count()}]";
+
+            var diffMsgFormat = "CircuitBreaker Diff: [{0}:, [{1}]]";
+            _logger.LogInformation(string.Format(diffMsgFormat, "Summary", changes));
+
+            if(diff.Added.Any())
+            {
+                _logger.LogInformation(string.Format(diffMsgFormat, "Added", string.Join(",", diff.Added)));
+            }
+
+            if(diff.Removed.Any())
+            {
+                _logger.LogInformation(string.Format(diffMsgFormat, "Removed", string.Join(",", diff.Removed)));
+            }
+
+            var maxDifference = int.Parse(maxDifferenceString);
+            var changeInCourseCount = receivedCourses.Count - currentCourseCount; // e.g. 100 existing, 98 incoming = difference of -2, i.e. there will be two less courses on find when completed
+            var absDiff = Math.Abs(changeInCourseCount);
+            var reason = $"Received {absDiff} " + (receivedCourses.Count > currentCourseCount ? "new courses" : "less courses");
+            if (absDiff > maxDifference)
+            {
+                _logger.LogError($"CircuitBreakerTripped: Change exceeded {limitKey}={maxDifference}. {reason}."
+                                 + $"\nCurrent courses {currentCourseCount}, received courses {receivedCourseCount}.");
+
+                return true;
+            }
+
+            // all checks passed
+            return false;
+        }
+    }
+}

--- a/tests/Unit.Tests/CircuitBreakerTests.cs
+++ b/tests/Unit.Tests/CircuitBreakerTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using GovUk.Education.SearchAndCompare.Api.Helpers;
+using GovUk.Education.SearchAndCompare.Domain.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Internal;
+using Moq;
+using NUnit.Framework;
+
+namespace GovUk.Education.SearchAndCompare.Api.Tests.Unit.Tests
+{
+    [TestFixture]
+    public class CircuitBreakerTests
+    {
+        private IQueryable<Course> _existingCourses;
+        private Mock<ILogger> _mockLogger;
+        private Mock<IConfiguration> _mockConfiguration;
+        private List<Course> _receivedCourses;
+
+        [SetUp]
+        public void Setup()
+        {
+            _existingCourses = new List<Course>().AsQueryable();
+            _mockLogger = new Mock<ILogger>();
+            _mockConfiguration = new Mock<IConfiguration>();
+            _receivedCourses = new List<Course>();
+        }
+
+        [Test]
+        public void LogsCourseCounts()
+        {
+            // Arrange
+            _receivedCourses = new List<Course>
+            {
+                new Course(),
+                new Course(),
+            };
+            _existingCourses = new List<Course>
+            {
+                new Course(),
+                new Course(),
+                new Course(),
+            }.AsQueryable();
+
+            // Act
+            RunCircuitBreaker();
+
+            // Assert
+            AssertLog(LogLevel.Information,
+                $"Circuit breaker: Current courses {_existingCourses.Count()}, received courses {_receivedCourses.Count}.");
+        }
+
+        [Test]
+        public void EmptyPayloadTrips()
+        {
+            // Arrange
+            _receivedCourses = new List<Course>();
+
+            // Act
+            var tripped = RunCircuitBreaker();
+
+            // Assert
+            tripped.Should().Be(true, "because no courses in payload");
+            AssertLog(LogLevel.Error,
+                "CircuitBreakerTripped: empty course list received");
+        }
+
+        [Test]
+        public void BypassWhenDatabaseEmpty()
+        {
+            // Arrange
+            _existingCourses = new List<Course>().AsQueryable();
+            _receivedCourses = new List<Course> { new Course() };
+
+            // Act
+            var tripped = RunCircuitBreaker();
+
+            // Assert
+            tripped.Should().Be(false, "because database is empty so nothing to protect");
+            AssertLog(LogLevel.Information,
+                "CircuitBreaker: bypassing checks as there are no courses in the database.");
+        }
+
+        [Test]
+        public void BypassWhenNotConfigured()
+        {
+            // Arrange
+            _existingCourses = new List<Course> { new Course() }.AsQueryable();
+            _receivedCourses = new List<Course> { new Course() };
+
+            // Act
+            var tripped = RunCircuitBreaker();
+
+            // Assert
+            tripped.Should().Be(false, "because unconfigured");
+            AssertLog(LogLevel.Warning,
+                "CircuitBreaker: bypassing checks as no limit configured. Configure with: CIRCUIT_BREAKER_COURSE_LIMIT");
+        }
+
+        [Test]
+        public void TripsWhenLimitExceeded()
+        {
+            // Arrange
+            _existingCourses = new List<Course>
+            {
+                new Course(), new Course(), new Course(), new Course(), new Course(),
+            }.AsQueryable();
+            _receivedCourses = new List<Course>
+            {
+                new Course(), new Course(),
+            };
+            SetLimit("2");
+
+            // Act
+            var tripped = RunCircuitBreaker();
+
+            // Assert
+            tripped.Should().Be(true, "too many courses removed");
+            AssertLog(LogLevel.Error,
+                "CircuitBreakerTripped: Change exceeded CIRCUIT_BREAKER_COURSE_LIMIT=2. Received 3 less courses.\n"
+                +"Current courses 5, received courses 2.");
+        }
+
+        [Test]
+        public void PassesWhenWithinLimit()
+        {
+            // Arrange
+            _existingCourses = new List<Course>
+            {
+                new Course(), new Course(), new Course(), new Course(), new Course(),
+            }.AsQueryable();
+            _receivedCourses = new List<Course>
+            {
+                new Course(), new Course(), new Course(),
+            };
+            SetLimit("2");
+
+            // Act
+            var tripped = RunCircuitBreaker();
+
+            // Assert
+            tripped.Should().Be(false, "diff is within configured limit");
+        }
+
+        private bool RunCircuitBreaker()
+        {
+            var circuitBreaker = new CircuitBreaker(_existingCourses, _mockLogger.Object, _mockConfiguration.Object);
+            return circuitBreaker.Run(_receivedCourses);
+        }
+
+        private void SetLimit(string limit)
+        {
+            _mockConfiguration.SetupGet(p => p[It.Is<string>(s => s == "CIRCUIT_BREAKER_COURSE_LIMIT")])
+                .Returns(limit);
+        }
+
+        private void AssertLog(LogLevel logLevel, string expectedMessage)
+        {
+            // can't mock the LoggerExtensions so mock the ILogger.Log() that they delegate to instead
+            // ref: https://stackoverflow.com/questions/43424095/how-to-unit-test-with-ilogger-in-asp-net-core/56728528#56728528
+            _mockLogger.Verify(x =>
+                x.Log(logLevel,
+                    0,
+                    It.Is<FormattedLogValues>(formattedLogValues => messageMatches(expectedMessage, formattedLogValues)),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<object, Exception, string>>()
+                ));
+        }
+
+        private static bool messageMatches(string expectedMessage, FormattedLogValues formattedLogValues)
+        {
+            // separate method as opposed to lambda for easier debugging
+
+            return formattedLogValues.ToString() == expectedMessage;
+        }
+    }
+}


### PR DESCRIPTION
### Context

Troubleshooting circuit breaker config on new environments has been remarkably tricky.

The circuit breaker is an important protection against accidental removal / addition of large amounts of courses to the public site.

Although this is being replaced it'll be a little while yet.

We want to be really sure the circuit breaker is active before shipping https://github.com/DFE-Digital/manage-courses-backend/pull/1059

### Changes proposed in this pull request

Two commits for proper legacy code maintenance

1. Add regression tests to existing code (had to refactor for testability)
2. Set a default limit and improve the log output

#### After

![Selection_20200107(001)](https://user-images.githubusercontent.com/19378/71891648-fa94a380-313e-11ea-8e11-9a9656d09153.png)

```
traces |
where message startswith "Circuit"
```

### Guidance to review

:eyes:

* Try and spot things that might break production
* Don't worry too much about the style etc, it's all going away soon